### PR TITLE
chore: bump integration to 1.3.10 and api to 1.1.3

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -8,7 +8,7 @@ CONF_SECRET_KEY = "secret_key"
 BASE_URL = "https://open.hyxicloud.com"
 
 MANUFACTURER = "HYXI Power"
-VERSION = "1.3.9"
+VERSION = "1.3.10"
 
 CONF_BACK_DISCOVERY = "back_discovery"
 

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api==1.1.2"
+    "hyxi-cloud-api==1.1.3"
   ],
-  "version": "1.3.9"
+  "version": "1.3.10"
 }


### PR DESCRIPTION
## Summary
This PR bumps the integration version to `1.3.10` and updates the `hyxi-cloud-api` requirement to `1.1.3` to include the fix for ghost sensors.

## Key Changes
- Updated `manifest.json` version to `1.3.10`.
- Updated `manifest.json` requirements to `hyxi-cloud-api==1.1.3`.
- Updated `const.py` `VERSION` to `1.3.10`.

## Why this is needed
To deliver the fix for the ghost PV sensors (PV3/PV4) that were appearing incorrectly for hybrid inverters. This version of the integration pins the library to the latest patched version.