### PR TITLE
chore: resolve python 3.14/pep 758 compatibility issues

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api==1.1.3"
+    "hyxi-cloud-api==1.1.4"
   ],
   "version": "1.3.10"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api==1.1.3"
+    "hyxi-cloud-api==1.1.4"
 ]
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py312"
 line-length = 88
 
 [tool.ruff.lint]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.13.1
-hyxi-cloud-api==1.1.3
+hyxi-cloud-api==1.1.4
 
 # Development/Linting tools
 ruff>=0.15.4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,4 @@ pytest-asyncio
 pytest-homeassistant-custom-component
 aiohttp>=3.13.4
 hypothesis>=6.100.0
-hyxi-cloud-api==1.1.3
+hyxi-cloud-api==1.1.4


### PR DESCRIPTION
# Summary
Aligns the Home Assistant integration with the updated `hyxi-cloud-api` v1.1.4 and resolves Python 3.14/PEP 758 compatibility issues in the linter stack.

# Key Changes
- **pyproject.toml**: Set `requires-python = ">=3.14"` to match HA 2026.3, but downgraded Ruff `target-version` to `py312`.
- **Requirements**: Updated `requirements.txt` and `requirements_test.txt` to pin `hyxi-cloud-api==1.1.4`.
- **manifest.json**: Updated API requirement to `v1.1.4`.

# Why this is needed
Home Assistant 2026.3 officially moved to Python 3.14. While we adopt this runtime requirement, we must maintain compatibility with existing development tools that do not yet support PEP 758 syntax (omitted parentheses in exception catches). This change ensures the integration remains stable and maintainable.