### PR TITLE
🧪 Add tests for _parse_device_type in sensor.py

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -96,7 +96,10 @@ def normalize_device_type(code: str | int | float) -> str:
     if "." in code_str:
         try:
             lookup_key = str(int(float(code_str)))
-        except ValueError, TypeError:
+        except (
+            ValueError,
+            TypeError,
+        ):
             # If float conversion fails (e.g. string labels), just use original code_str
             pass
 

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -876,7 +876,10 @@ class HyxiSensor(HyxiBaseSensor):
             return None
         try:
             return int(round(float(value), 0))
-        except ValueError, TypeError:
+        except (
+            ValueError,
+            TypeError,
+        ):
             return self._process_numeric_value(value)
 
     def _parse_collect_time(self, dev_data, value):
@@ -893,7 +896,12 @@ class HyxiSensor(HyxiBaseSensor):
             if val_int > 9999999999:
                 val_int = val_int // 1000
             return datetime.fromtimestamp(val_int, tz=UTC)
-        except ValueError, TypeError, OSError, OverflowError:
+        except (
+            ValueError,
+            TypeError,
+            OSError,
+            OverflowError,
+        ):
             return None
 
     def _parse_last_seen(self, dev_data, value):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ ensure_mock("homeassistant.helpers")
 ensure_mock("homeassistant.helpers.aiohttp_client")
 ensure_mock("homeassistant.helpers.device_registry")
 ensure_mock("homeassistant.helpers.entity_platform")
+ensure_mock("homeassistant.helpers.restore_state")
 ensure_mock(
     "homeassistant.helpers.update_coordinator", {"UpdateFailed": MockUpdateFailed}
 )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -63,11 +63,12 @@ mock_api = MagicMock()
 mock_api.__version__ = "1.0.4"
 sys.modules["hyxi_cloud_api"] = mock_api
 
-from custom_components.hyxi_cloud.sensor import HyxiSensor
 
 @pytest.fixture
 def mock_sensor():
     """Create a mock HyxiSensor instance for testing parsers."""
+    from custom_components.hyxi_cloud.sensor import HyxiSensor
+
     coordinator = MagicMock()
     description = MagicMock()
     description.key = "test_sensor"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
 # 1. THE BULLETPROOF MOCK (similar to test_sensor_logic.py)
 class FakeBase:
     pass

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -6,9 +6,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.hyxi_cloud.sensor import HyxiSensor
-
-
 # 1. THE BULLETPROOF MOCK (similar to test_sensor_logic.py)
 class FakeBase:
     pass
@@ -49,6 +46,7 @@ sys.modules["homeassistant.components.sensor"] = mock_sensor_comp
 # Mock helpers
 mock_coordinator = MagicMock()
 mock_coordinator.CoordinatorEntity = FakeCoordinatorEntity
+
 mock_restore = MagicMock()
 mock_restore.RestoreEntity = FakeRestoreEntity
 
@@ -57,6 +55,7 @@ sys.modules["homeassistant.helpers.restore_state"] = mock_restore
 sys.modules["homeassistant.helpers.update_coordinator"] = mock_coordinator
 sys.modules["homeassistant.helpers.aiohttp_client"] = mock_ha
 sys.modules["homeassistant.util"] = mock_ha
+sys.modules["homeassistant.util.dt"] = mock_ha
 sys.modules["aiohttp"] = MagicMock()
 
 # Mock hyxi_cloud_api
@@ -64,6 +63,7 @@ mock_api = MagicMock()
 mock_api.__version__ = "1.0.4"
 sys.modules["hyxi_cloud_api"] = mock_api
 
+from custom_components.hyxi_cloud.sensor import HyxiSensor
 
 @pytest.fixture
 def mock_sensor():
@@ -152,3 +152,75 @@ def test_parse_collect_time_errors(mock_sensor):
     with patch("custom_components.hyxi_cloud.sensor.datetime") as mock_dt:
         mock_dt.fromtimestamp.side_effect = OverflowError()
         assert mock_sensor._parse_collect_time({}, 1234567890) is None
+
+
+def test_parse_device_type_valid(mock_sensor):
+    """Test _parse_device_type with valid keys and codes."""
+    # device_type_code
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "1"}, "any")
+        == "hybrid_inverter"
+    )
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "2"}, "any")
+        == "grid_connected_inverter"
+    )
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "3"}, "any") == "collector"
+    )
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "15"}, "any") == "micro_ess"
+    )
+
+    # deviceType
+    assert (
+        mock_sensor._parse_device_type({"deviceType": "106"}, "any")
+        == "hybrid_inverter"
+    )
+
+    # devType
+    assert mock_sensor._parse_device_type({"devType": "607"}, "any") == "collector"
+
+    # deviceCode
+    assert (
+        mock_sensor._parse_device_type({"deviceCode": "HYBRID_INVERTER"}, "any")
+        == "hybrid_inverter"
+    )
+
+    # Check precedence (device_type_code > deviceType > devType > deviceCode)
+    assert (
+        mock_sensor._parse_device_type(
+            {
+                "device_type_code": "2",
+                "deviceType": "1",
+                "devType": "3",
+                "deviceCode": "15",
+            },
+            "any",
+        )
+        == "grid_connected_inverter"
+    )
+
+
+def test_parse_device_type_unknown(mock_sensor):
+    """Test _parse_device_type with unknown or missing data."""
+    # Invalid code
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "999"}, "any") == "unknown"
+    )
+
+    # Missing keys
+    assert mock_sensor._parse_device_type({"some_other_key": "1"}, "any") == "unknown"
+
+    # Empty dict
+    assert mock_sensor._parse_device_type({}, "any") == "unknown"
+
+    # Value is ignored
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "1"}, None)
+        == "hybrid_inverter"
+    )
+    assert (
+        mock_sensor._parse_device_type({"device_type_code": "1"}, "hybrid_inverter")
+        == "hybrid_inverter"
+    )


### PR DESCRIPTION
🎯 **What:** This PR adds test coverage for the previously untested `_parse_device_type` function in `sensor.py`. It also identifies and corrects a SyntaxError caused by legacy Python 2 exception syntax (`except ValueError, TypeError:`) in both `const.py` and `sensor.py` that would prevent execution in Python 3.

📊 **Coverage:** The new tests in `tests/test_parsers.py` verify that `_parse_device_type` correctly maps multiple keys (`device_type_code`, `deviceType`, `devType`, `deviceCode`) to expected normalized strings using `normalize_device_type`, accurately handles invalid keys and unknown device codes, and safely ignores the `value` parameter. The correct precedence resolution of keys is also verified.
 
✨ **Result:** Enhanced test coverage and stability by thoroughly validating the parsing logic and eliminating invalid legacy syntax.

---
*PR created automatically by Jules for task [8136617896299666503](https://jules.google.com/task/8136617896299666503) started by @Veldkornet*