### PR TITLE
refactor(init): guard battery stub creation when bat_sn is a first-class device in coordinator.data

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -64,8 +64,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry = dr.async_get(hass)
 
-    # Pre-register devices to fix 'via_device' order dependency (Two-pass)
-    # Pass 1: Ensure all base devices exist in the registry
+    # Two-pass device registration to guarantee correct via_device ordering.
+    # Without Pass 1, a child registered before its parent would fail the
+    # via_device lookup and appear as an orphaned device in Home Assistant.
+    #
+    # Pass 1: Register every device as a standalone entry (no relationships).
+    #         This ensures all SNs are present in the registry before Pass 2
+    #         attempts to link them.
     for sn, dev_data in coordinator.data.items():
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
@@ -78,24 +83,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             serial_number=sn,
         )
 
-    # Pass 2: Establish relationships (Battery -> Inverter, Inverter -> Collector)
+    # Pass 2: Establish parent→child relationships now that all devices exist.
     for sn, dev_data in coordinator.data.items():
         metrics = dev_data.get("metrics", {})
 
-        # 1. Handle Battery relationship
+        # 1. Handle Battery relationship.
+        #    Guard: if bat_sn is already a first-class device in coordinator.data
+        #    it was registered in Pass 1 with full metadata — skip the sparse stub
+        #    and just link it via_device to avoid overwriting the full entry.
         bat_sn = metrics.get("batSn")
         if bat_sn:
-            device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, bat_sn)},
-                name=f"Battery {bat_sn}",
-                manufacturer=MANUFACTURER,
-                model="Energy Storage System",
-                serial_number=bat_sn,
-                via_device=(DOMAIN, sn),
-            )
+            if bat_sn in coordinator.data:
+                # Already registered with full metadata in Pass 1; just set the link.
+                device_registry.async_get_or_create(
+                    config_entry_id=entry.entry_id,
+                    identifiers={(DOMAIN, bat_sn)},
+                    via_device=(DOMAIN, sn),
+                )
+            else:
+                # Battery is not a standalone device — create a minimal stub.
+                device_registry.async_get_or_create(
+                    config_entry_id=entry.entry_id,
+                    identifiers={(DOMAIN, bat_sn)},
+                    name=f"Battery {bat_sn}",
+                    manufacturer=MANUFACTURER,
+                    model="Energy Storage System",
+                    serial_number=bat_sn,
+                    via_device=(DOMAIN, sn),
+                )
 
-        # 2. Handle Parent Collector relationship
+        # 2. Handle Parent Collector relationship.
         parent_sn = metrics.get("parentSn")
         if parent_sn:
             device_registry.async_get_or_create(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -354,3 +354,72 @@ async def test_async_reload_entry(mock_hass, mock_entry):
         mock_hass.config_entries.async_reload.assert_called_once_with(
             mock_entry.entry_id
         )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_battery_first_class_device(mock_hass, mock_entry):
+    """Test that bat_sn already in coordinator.data is linked, not re-stubbed.
+
+    When a battery is discovered as a standalone device (it appears in
+    coordinator.data with full metadata), Pass 2 must only set the via_device
+    link rather than creating a sparse 'Battery {sn}' stub that would
+    overwrite the richer entry registered in Pass 1.
+    """
+    with (
+        patch(
+            "custom_components.hyxi_cloud.__init__.HyxiDataUpdateCoordinator"
+        ) as mock_coordinator_class,
+        patch("custom_components.hyxi_cloud.__init__.async_get_clientsession"),
+        patch("custom_components.hyxi_cloud.__init__.HyxiApiClient"),
+        patch("custom_components.hyxi_cloud.__init__.dr.async_get") as mock_dr_get,
+        patch("custom_components.hyxi_cloud.__init__.async_reload_entry"),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.data = {
+            # Inverter knows about its battery via metrics
+            "INVERTER_SN": {
+                "device_name": "Hybrid Inverter",
+                "model": "HYB-5K",
+                "sw_version": "v2",
+                "hw_version": "hw2",
+                "metrics": {"batSn": "BATTERY_SN"},
+            },
+            # Battery is also a first-class device in its own right
+            "BATTERY_SN": {
+                "device_name": "Battery Pack",
+                "model": "ESS-10",
+                "sw_version": "v1",
+                "hw_version": "hw1",
+                "metrics": {},
+            },
+        }
+
+        mock_registry = MagicMock()
+        mock_dr_get.return_value = mock_registry
+
+        result = await async_setup_entry(mock_hass, mock_entry)
+
+        assert result is True
+
+        calls = mock_registry.async_get_or_create.call_args_list
+
+        # Pass 1: 2 calls (INVERTER_SN, BATTERY_SN)
+        # Pass 2: 1 call — link BATTERY_SN via_device to INVERTER_SN (guard path)
+        assert mock_registry.async_get_or_create.call_count == 3
+
+        # Pass 1 — INVERTER_SN registered with full metadata
+        assert calls[0].kwargs["identifiers"] == {(DOMAIN, "INVERTER_SN")}
+        assert calls[0].kwargs["name"] == "Hybrid Inverter"
+
+        # Pass 1 — BATTERY_SN registered with full metadata (not a stub)
+        assert calls[1].kwargs["identifiers"] == {(DOMAIN, "BATTERY_SN")}
+        assert calls[1].kwargs["name"] == "Battery Pack"
+        assert calls[1].kwargs["model"] == "ESS-10"
+
+        # Pass 2 — guard path: link only, no name/model/serial overwrite
+        assert calls[2].kwargs["identifiers"] == {(DOMAIN, "BATTERY_SN")}
+        assert calls[2].kwargs["via_device"] == (DOMAIN, "INVERTER_SN")
+        assert "name" not in calls[2].kwargs
+        assert "model" not in calls[2].kwargs
+        assert "serial_number" not in calls[2].kwargs


### PR DESCRIPTION
## Summary

Addresses the sound architectural concern raised in Jules' rejected PRs #341/#343 (device registry ordering), without resorting to sort-based registration or changing the proven two-pass approach. The two-pass is preserved and correct — this PR improves its Pass 2 battery handling and documents *why* the two-pass is necessary.

## Key Changes

### `custom_components/hyxi_cloud/__init__.py`

- **Pass 2 battery guard**: When `bat_sn` is found in a device's metrics, the code now checks whether that battery SN is already present in `coordinator.data` as a first-class device:
  - **If yes** (battery was discovered directly by the API): emit a link-only `async_get_or_create` call with only `identifiers` and `via_device`. This prevents the sparse `{"name": "Battery {sn}", model: "Energy Storage System"}` stub from overwriting the richer device entry (with full `sw_version`, `hw_version`, and proper `device_name`) that was already registered in Pass 1.
  - **If no** (battery is only known via the inverter's metrics): create the minimal stub exactly as before.
- **Improved comments**: Explain precisely what race condition the two-pass prevents (a child registered with `via_device` pointing to a parent that hasn't been registered yet), and what each pass is responsible for.

### `tests/test_init.py`

- Added `test_async_setup_entry_battery_first_class_device`: Verifies the guard path — when a battery SN appears in both `coordinator.data` and an inverter's `batSn` metric, Pass 2 emits a link-only call with no `name`, `model`, or `serial_number` keys (confirming the full entry from Pass 1 is not overwritten).

## Why This Is Needed

In production installations with a battery that the HYXI API returns as a first-class device (common on HYB systems), the previous code would call `async_get_or_create` twice with conflicting data: once in Pass 1 with the full device profile, and again in Pass 2 with a minimal stub. Home Assistant's `async_get_or_create` merges these, but the second call's `model="Energy Storage System"` could shadow the correct model string if the registry entry had already been written.

## Verification

- **117 tests passing, 1 skipped** (`python3 -m pytest tests/ -x -q`)
- **All 12 pre-commit checks passing**