### PR TITLE
test(sensor): add coverage for _parse_app_sw (rebased #351)

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -253,3 +253,15 @@ def test_parse_device_type_unknown(mock_sensor):
         mock_sensor._parse_device_type({"device_type_code": "1"}, "hybrid_inverter")
         == "hybrid_inverter"
     )
+
+
+def test_parse_app_sw(mock_sensor):
+    """Test _parse_app_sw returns sw_version."""
+    # Present
+    assert mock_sensor._parse_app_sw({"sw_version": "v1.0.0"}, "ignored") == "v1.0.0"
+
+    # Missing
+    assert mock_sensor._parse_app_sw({"other_key": "val"}, "ignored") is None
+
+    # Empty
+    assert mock_sensor._parse_app_sw({}, "ignored") is None


### PR DESCRIPTION
## Summary

Applies the `test_parse_app_sw` test coverage from PR #351, rebased cleanly onto current `main`. The original #351 branch pre-dated the #352 `NULL_VALUES` refactor and had import ordering issues (E402/C0413) that caused pre-commit failures. This PR contains only the meaningful addition from #351 with no linting issues.

## Key Changes

### `tests/test_parsers.py`
- Added `test_parse_app_sw`: covers `_parse_app_sw` for the present key, a missing key, and an empty dict — all three return paths.

## Why This Is Needed

`_parse_app_sw` had no dedicated unit test. This closes that gap and ensures any future refactor of the sw_version parser is caught immediately.

## Verification

- **118 tests passing, 1 skipped** (`python3 -m pytest tests/ -x -q`)
- **All 12 pre-commit hooks passing**