### PR TITLE
chore: bump version to 1.4.0 and pin hyxi-cloud-api==1.2.0

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api==1.1.5"
+    "hyxi-cloud-api==1.2.0"
   ],
-  "version": "1.3.11"
+  "version": "1.4.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-hyxi-cloud"
-version = "1.3.11"
+version = "1.4.0"
 description = "HYXI ⚡️🔋☀️ Integration for HomeAssistant using HYXI Cloud ☁️"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api==1.1.5"
+    "hyxi-cloud-api==1.2.0"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api==1.1.5
+hyxi-cloud-api==1.2.0
 
 # Development/Linting tools
 ruff>=0.15.12

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.4
-hyxi-cloud-api==1.1.5
+hyxi-cloud-api==1.2.0


### PR DESCRIPTION
## Summary

Prepares the `ha-hyxi-cloud` integration for the **v1.4.0** release and pins the updated upstream library dependency.

## Key Changes

| File | Change |
|---|---|
| `pyproject.toml` | `version` `1.3.11` → **`1.4.0`**; `hyxi-cloud-api` pin `1.1.5` → **`1.2.0`** |
| `manifest.json` | `version` `1.3.11` → **`1.4.0`**; `hyxi-cloud-api` pin `1.1.5` → **`1.2.0`** |
| `requirements.txt` | `hyxi-cloud-api` pin `1.1.5` → **`1.2.0`** |
| `requirements_test.txt` | `hyxi-cloud-api` pin `1.1.5` → **`1.2.0`** |

## Why this is needed

Consolidates the security, performance, and correctness improvements that have landed on `main` since `v1.3.10` into a named `v1.4.0` release. The minor version increment (vs a patch) reflects the breadth of changes: a DoS remediation (`_get_metric_float`), battery registration guard logic, the `NULL_VALUES` performance refactor, and CVE-2025-71176 remediation via `pytest>=9.0.3`. The upstream `hyxi-cloud-api` pin is advanced to `1.2.0` to capture the corresponding API security hardening and performance improvements.
