### PR TITLE
🧹 Refactor: Remove unused ClassVar and move _MAX_POWER_KEYS to module level

### DIFF
--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -1,7 +1,6 @@
 """Number platform for HYXI Cloud device control power settings."""
 
 import logging
-from typing import ClassVar
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +20,11 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_MAX_POWER_KEYS = {
+    "charge": "maxChargePower",
+    "discharge": "maxDischargePower",
+}
 
 
 async def async_setup_entry(
@@ -68,11 +72,6 @@ class HyxiPowerNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
     _attr_native_min_value = 1
     _attr_icon = "mdi:flash"
 
-    _MAX_POWER_KEYS: ClassVar[dict[str, str]] = {
-        "charge": "maxChargePower",
-        "discharge": "maxDischargePower",
-    }
-
     def __init__(
         self,
         coordinator,
@@ -87,7 +86,7 @@ class HyxiPowerNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         self._attr_unique_id = f"hyxi_{sn}_{direction}_power"
         self._attr_translation_key = f"{direction}_power"
         metrics = dev_data.get("metrics") or {}
-        metric_key = self._MAX_POWER_KEYS.get(direction, "")
+        metric_key = _MAX_POWER_KEYS.get(direction, "")
         self._attr_native_max_value = int(_safe_int(metrics.get(metric_key), 10000))
         self._attr_native_value = 100
         self._attr_device_info = {


### PR DESCRIPTION
🎯 **What:** Removed the unused `ClassVar` import from `typing` in `custom_components/hyxi_cloud/number.py` and moved the `_MAX_POWER_KEYS` dictionary to a module-level constant to prevent `ruff`'s `RUF012` mutable class attribute warning.
💡 **Why:** `ClassVar` was correctly identified by static analysis as unused for type hinting when moved outside the class, but simply removing it would trigger a `RUF012` warning for a mutable class attribute. Moving the constant to the module level improves code cleanliness, satisfies static analysis tools, and avoids runtime mutation risks.
✅ **Verification:** Verified that tests pass (with expected environment-specific exceptions ignored) and that `ruff check` and `ruff format` run cleanly without errors. Code review confirmed the changes are correct and introduce no regressions.
✨ **Result:** A cleaner `number.py` file without unnecessary imports and with properly scoped constants.

---
*PR created automatically by Jules for task [13947828684187200725](https://jules.google.com/task/13947828684187200725) started by @Veldkornet*