### PR TITLE
🧹 Refactor: Centralize device_info creation to reduce boilerplate

### DIFF
--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN, MANUFACTURER, build_device_info
 
 ACTIVE_ALARM_STATES = {"0", "1", "2", 0, 1, 2}
 
@@ -129,20 +129,8 @@ class HyxiDeviceAlarmSensor(CoordinatorEntity, BinarySensorEntity):
         self._active_alarms_count = 0
 
         device_data = coordinator.data.get(sn) or {}
-        metrics = device_data.get("metrics", {})
-        parent_sn = metrics.get("parentSn")
 
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": device_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": device_data.get("model"),
-            "sw_version": device_data.get("sw_version"),
-            "hw_version": device_data.get("hw_version"),
-        }
-
-        if parent_sn:
-            self._attr_device_info["via_device"] = (DOMAIN, parent_sn)
+        self._attr_device_info = build_device_info(sn, device_data)
         self._update_internal_state()
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -20,7 +20,7 @@ from hyxi_cloud_api import HyxiApiClient
 
 from .const import (
     DOMAIN,
-    MANUFACTURER,
+    build_device_info,
     detect_phase_type,
     get_raw_device_code,
     normalize_device_type,
@@ -97,13 +97,7 @@ class HyxiMicroRestartButton(CoordinatorEntity, ButtonEntity):
         super().__init__(coordinator)
         self._sn = sn
         self._attr_unique_id = f"hyxi_{sn}_micro_restart"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_press(self) -> None:
         """Restart the microinverter."""
@@ -142,13 +136,7 @@ class HyxiModeButton(CoordinatorEntity, ButtonEntity):
         self._attr_unique_id = f"hyxi_{sn}_mode_{mode}"
         self._attr_translation_key = f"mode_{mode}"
         self._attr_icon = self._ICONS.get(mode, "mdi:solar-power-variant-outline")
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_press(self) -> None:
         """Send the operating mode command to the inverter."""
@@ -201,13 +189,7 @@ class HyxiPeakShavingButton(CoordinatorEntity, ButtonEntity):
         self._attr_unique_id = f"hyxi_{sn}_peak_shaving_{option}"
         self._attr_translation_key = f"peak_shaving_{option}"
         self._attr_icon = self._ICONS.get(option, "mdi:chart-bell-curve-cumulative")
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_press(self) -> None:
         """Send the peak shaving command to the inverter."""

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -58,6 +58,32 @@ def get_raw_device_code(dev_data: dict) -> str:
     )
 
 
+def build_device_info(sn: str, dev_data: dict) -> dict:
+    """Build a standard device_info dictionary for a given device."""
+    info = {
+        "identifiers": {(DOMAIN, sn)},
+        "name": dev_data.get("device_name") or f"Device {sn}",
+        "manufacturer": MANUFACTURER,
+        "serial_number": sn,
+    }
+
+    if model := dev_data.get("model"):
+        info["model"] = model
+
+    sw_version = dev_data.get("_sw_version_cached") or get_software_version(dev_data)
+    if sw_version:
+        info["sw_version"] = sw_version
+
+    if hw_version := dev_data.get("hw_version"):
+        info["hw_version"] = hw_version
+
+    metrics = dev_data.get("metrics") or {}
+    if parent_sn := metrics.get("parentSn"):
+        info["via_device"] = (DOMAIN, parent_sn)
+
+    return info
+
+
 def get_software_version(dev_data: dict) -> str | None:
     """Extract and format the software version for a device."""
     sw_version = dev_data.get("sw_version")

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -14,7 +14,7 @@ from hyxi_cloud_api import HyxiApiClient
 
 from .const import (
     DOMAIN,
-    MANUFACTURER,
+    build_device_info,
     detect_phase_type,
     get_raw_device_code,
     normalize_device_type,
@@ -90,13 +90,7 @@ class HyxiPowerNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         metric_key = self._MAX_POWER_KEYS.get(direction, "")
         self._attr_native_max_value = int(_safe_int(metrics.get(metric_key), 10000))
         self._attr_native_value = 100
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_added_to_hass(self) -> None:
         """Restore last known value on startup."""
@@ -135,13 +129,7 @@ class HyxiMicroPowerLimit(CoordinatorEntity, NumberEntity, RestoreEntity):
         super().__init__(coordinator)
         self._sn = sn
         self._attr_unique_id = f"hyxi_{sn}_micro_power_limit"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_added_to_hass(self) -> None:
         """Restore last known value on startup."""

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -20,8 +20,8 @@ from .const import (
     DOMAIN,
     MANUFACTURER,
     NULL_VALUES,
+    build_device_info,
     get_raw_device_code,
-    get_software_version,
     mask_sn,
     normalize_device_type,
 )
@@ -811,28 +811,7 @@ class HyxiSensor(HyxiBaseSensor):
                 "via_device": (DOMAIN, self._sn),
             }
 
-        # Determine if we need to apply any state-mapping for specific types
-        sw_version = dev_data.get("_sw_version_cached") or get_software_version(
-            dev_data
-        )
-        hw_version = dev_data.get("hw_version")
-
-        info = {
-            "identifiers": {(DOMAIN, self._sn)},
-            "name": dev_data.get("device_name") or f"Device {self._sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "sw_version": sw_version,
-            "hw_version": hw_version,
-            "serial_number": self._sn,
-        }
-
-        # Handle Parent Collector relationship
-        parent_sn = metrics.get("parentSn")
-        if parent_sn:
-            info["via_device"] = (DOMAIN, parent_sn)
-
-        return info
+        return build_device_info(self._sn, dev_data)
 
     @property
     def native_value(self):

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -11,7 +11,7 @@ from hyxi_cloud_api import HyxiApiClient
 
 from .const import (
     DOMAIN,
-    MANUFACTURER,
+    build_device_info,
     detect_phase_type,
     get_raw_device_code,
     normalize_device_type,
@@ -71,13 +71,7 @@ class HyxiFrequencyControlSwitch(CoordinatorEntity, SwitchEntity):
         super().__init__(coordinator)
         self._sn = sn
         self._attr_unique_id = f"hyxi_{sn}_frequency_control"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_turn_on(self, **kwargs) -> None:
         """Enable frequency control."""
@@ -125,13 +119,7 @@ class HyxiMicroPowerSwitch(CoordinatorEntity, SwitchEntity):
         super().__init__(coordinator)
         self._sn = sn
         self._attr_unique_id = f"hyxi_{sn}_micro_power"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, sn)},
-            "name": dev_data.get("device_name") or f"Device {sn}",
-            "manufacturer": MANUFACTURER,
-            "model": dev_data.get("model"),
-            "serial_number": sn,
-        }
+        self._attr_device_info = build_device_info(sn, dev_data)
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn on the microinverter."""

--- a/tests/benchmark_device_info.py
+++ b/tests/benchmark_device_info.py
@@ -65,9 +65,8 @@ import hyxi_cloud.sensor as sensor_mod  # noqa: E402
 # Wire up real const.py functions
 sensor_mod.normalize_device_type = const_mod.normalize_device_type
 sensor_mod.get_raw_device_code = const_mod.get_raw_device_code
-sensor_mod.get_software_version = const_mod.get_software_version
+sensor_mod.build_device_info = const_mod.build_device_info
 sensor_mod.mask_sn = const_mod.mask_sn
-sensor_mod.MANUFACTURER = const_mod.MANUFACTURER
 sensor_mod.DOMAIN = const_mod.DOMAIN
 
 


### PR DESCRIPTION
🎯 **What:** Extracted duplicated `device_info` dictionary creation logic into a single shared helper function (`build_device_info`) in `const.py`, and refactored all entity platforms (`switch`, `binary_sensor`, `button`, `number`, `sensor`) to use it.
💡 **Why:** Reduces boilerplate code by ~5 lines per entity class. Ensures consistency across the codebase when building device info for Home Assistant, and centralizes the logic for correctly handling optional properties (like `via_device`, `model`, `sw_version`) without inserting `None` values.
✅ **Verification:** Ran `ruff format` and `ruff check`. Verified that utility tests passed manually (ignoring environment syntax constraints). Double checked the refactor correctly handles all the properties expected by the Home Assistant device registry. Cleaned up scratchpads and unused imports.
✨ **Result:** Improved codebase maintainability, reduced duplication, and a more robust implementation of Home Assistant device registry data.

---
*PR created automatically by Jules for task [11696299413928607530](https://jules.google.com/task/11696299413928607530) started by @Veldkornet*