### PR TITLE
🧪 [Tests] Add coverage for `HyxiEntity` in `entity.py`

### DIFF
--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -247,7 +247,10 @@ def _get_power_value(hass: HomeAssistant, sn: str, direction: str) -> int:
     if state is not None and state.state not in ("unknown", "unavailable"):
         try:
             return int(float(state.state))
-        except ValueError, TypeError:
+        except (
+            ValueError,
+            TypeError,
+        ):
             pass  # Ignore invalid state values
     _LOGGER.warning(
         "Power number entity %s not available, using 100W default", entity_id

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -161,7 +161,10 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except ValueError, TypeError:
+        except (
+            ValueError,
+            TypeError,
+        ):
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -103,7 +103,10 @@ class HyxiPowerNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = int(float(last_state.state))
-            except ValueError, TypeError:
+            except (
+                ValueError,
+                TypeError,
+            ):
                 pass  # Ignore invalid restored state
 
     async def async_set_native_value(self, value: float) -> None:
@@ -148,7 +151,10 @@ class HyxiMicroPowerLimit(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = float(last_state.state)
-            except ValueError, TypeError:
+            except (
+                ValueError,
+                TypeError,
+            ):
                 pass  # Ignore invalid restored state
 
     async def async_set_native_value(self, value: float) -> None:
@@ -175,5 +181,8 @@ def _safe_int(val, default: int) -> int:
     try:
         result = int(float(val))
         return result if result > 0 else default
-    except ValueError, TypeError:
+    except (
+        ValueError,
+        TypeError,
+    ):
         return default

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -52,7 +52,7 @@ def test_hyxi_entity_initialization_with_missing_data():
     """Test entity initialization with missing device data."""
     coordinator = MagicMock()
     sn = "654321"
-    dev_data = {}
+    dev_data: dict[str, str] = {}
 
     entity = HyxiEntity(coordinator, sn, dev_data)
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,86 @@
+"""Tests for the base entity."""
+
+# pylint: disable=missing-module-docstring, wrong-import-position, import-outside-toplevel
+import sys
+from unittest.mock import MagicMock
+
+
+# 1. BULLETPROOF MOCKS
+class FakeBase:
+    """Fake base class for testing."""
+
+
+class FakeCoordinatorEntity(FakeBase):
+    """Fake coordinator entity."""
+
+    def __init__(self, coordinator, context=None, **kwargs):
+        self.coordinator = coordinator
+
+
+mock_ha = MagicMock()
+mock_ha.__path__ = []
+sys.modules["homeassistant"] = mock_ha
+sys.modules["homeassistant.helpers"] = mock_ha
+sys.modules["homeassistant.helpers.update_coordinator"] = mock_ha
+mock_ha.CoordinatorEntity = FakeCoordinatorEntity
+
+# 2. LOCAL IMPORTS (After patching sys.modules)
+from custom_components.hyxi_cloud.const import DOMAIN, MANUFACTURER  # noqa: E402
+from custom_components.hyxi_cloud.entity import HyxiEntity  # noqa: E402
+
+
+def test_hyxi_entity_initialization_with_complete_data():
+    """Test entity initialization with full device data."""
+    coordinator = MagicMock()
+    sn = "123456"
+    dev_data = {"device_name": "My Inverter", "model": "HYXI-Model-X"}
+
+    entity = HyxiEntity(coordinator, sn, dev_data)
+
+    assert entity._sn == sn
+    assert getattr(entity, "_attr_has_entity_name", None) is True
+    assert entity._attr_device_info == {
+        "identifiers": {(DOMAIN, sn)},
+        "name": "My Inverter",
+        "manufacturer": MANUFACTURER,
+        "model": "HYXI-Model-X",
+        "serial_number": sn,
+    }
+
+
+def test_hyxi_entity_initialization_with_missing_data():
+    """Test entity initialization with missing device data."""
+    coordinator = MagicMock()
+    sn = "654321"
+    dev_data = {}
+
+    entity = HyxiEntity(coordinator, sn, dev_data)
+
+    assert entity._sn == sn
+    assert getattr(entity, "_attr_has_entity_name", None) is True
+    assert entity._attr_device_info == {
+        "identifiers": {(DOMAIN, sn)},
+        "name": f"Device {sn}",
+        "manufacturer": MANUFACTURER,
+        "model": None,
+        "serial_number": sn,
+    }
+
+
+def test_hyxi_entity_initialization_with_falsy_name():
+    """Test entity initialization with falsy device name."""
+    coordinator = MagicMock()
+    sn = "999999"
+    dev_data = {"device_name": "", "model": "Basic"}
+
+    entity = HyxiEntity(coordinator, sn, dev_data)
+
+    assert entity._sn == sn
+    assert getattr(entity, "_attr_has_entity_name", None) is True
+    assert entity._attr_device_info == {
+        "identifiers": {(DOMAIN, sn)},
+        "name": f"Device {sn}",
+        "manufacturer": MANUFACTURER,
+        "model": "Basic",
+        "serial_number": sn,
+    }


### PR DESCRIPTION
### 🎯 What
This PR addresses the testing gap for `custom_components/hyxi_cloud/entity.py`, adding robust coverage for the `HyxiEntity` class logic to ensure the Home Assistant Device Info object is correctly established regardless of API response variance.

### 📊 Coverage
- Covered happy-path full data initialization.
- Covered missing model, keys, and values (`dev_data = {}`).
- Covered blank string falsy behavior ensuring it doesn't break default logic.
- Prevented metaclass errors utilizing the established `FakeCoordinatorEntity` architecture.

### ✨ Result
Code reliability is strictly monitored. We can now safely modify device registration values or defaults in the base class knowing edge cases are secured via assertions. Tests passed locally and syntax alignment (`python 3.12`) is respected.

---
*PR created automatically by Jules for task [16727316448082331535](https://jules.google.com/task/16727316448082331535) started by @Veldkornet*