### PR TITLE
fix: Cast ENUM sensor values to strings to prevent unavailable states

### DIFF
--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -1195,7 +1195,14 @@ class HyxiSensor(HyxiBaseSensor):
             ):
                 value = metrics.get("efpv")
 
-        self._attr_native_value = self._parser_func(dev_data, value)
+        parsed_val = self._parser_func(dev_data, value)
+        if (
+            parsed_val is not None
+            and self.entity_description.device_class == SensorDeviceClass.ENUM
+        ):
+            self._attr_native_value = str(parsed_val)
+        else:
+            self._attr_native_value = parsed_val
 
 
 class HyxiLastUpdateSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_sensor_logic.py
+++ b/tests/test_sensor_logic.py
@@ -1044,11 +1044,11 @@ async def test_new_telemetry_keys_registration_and_parsing():
         assert key in registered_keys, f"{key} was not registered as a sensor"
 
     # Verify enum and integer casting of metrics
-    assert registered_by_key["invSts"].native_value == 2
-    assert registered_by_key["faultSts"].native_value == 1
-    assert registered_by_key["gridSts"].native_value == 0
-    assert registered_by_key["deviceGridConn"].native_value == 1
-    assert registered_by_key["deviceSwitchStatus"].native_value == 0
+    assert registered_by_key["invSts"].native_value == "2"
+    assert registered_by_key["faultSts"].native_value == "1"
+    assert registered_by_key["gridSts"].native_value == "0"
+    assert registered_by_key["deviceGridConn"].native_value == "1"
+    assert registered_by_key["deviceSwitchStatus"].native_value == "0"
     assert registered_by_key["ratedFrequency"].native_value == 50
 
     assert registered_by_key["pvPower"].native_value == 1200.5


### PR DESCRIPTION
#### Summary
This pull request ensures that all `ENUM` device class sensors (such as `invSts`, `faultSts`, `gridSts`, `deviceGridConn`, and `deviceSwitchStatus`) have their parsed state values cast as strings. 

#### Key Changes
- Modified `_update_native_value` in [sensor.py](file:///Users/darrynstorm/Git/ha-hyxi-cloud/custom_components/hyxi_cloud/sensor.py) to check if the sensor's `device_class` is `SensorDeviceClass.ENUM`, and if so, cast the parsed value to a string.
- Updated unit test assertions in [test_sensor_logic.py](file:///Users/darrynstorm/Git/ha-hyxi-cloud/tests/test_sensor_logic.py) to check for string status values (e.g. `"2"` or `"1"`) rather than integers.

#### Why this is needed
Home Assistant's schema validation for `ENUM` device class sensors requires that the entity's state matches one of the string options defined in its metadata/translations. When the integration returned raw integers (like `1` or `2`), Home Assistant's validator failed to match them against the string options list (e.g., `["0", "1", "2"]`), resulting in the entities becoming `unavailable` in the UI.
