### PR TITLE
feat: add clear active alarms button and resolved alarm filtering

### DIFF
--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -158,8 +158,11 @@ class HyxiDeviceAlarmSensor(CoordinatorEntity, BinarySensorEntity):
         self._active_alarms_count = sum(
             1
             for a in self._alarms
-            if a.get("alarmState") in active_states
-            or a.get("alarmstate") in active_states
+            if (
+                a.get("alarmState") in active_states
+                or a.get("alarmstate") in active_states
+            )
+            and not (a.get("endTime") or a.get("endtime"))
         )
 
     @property

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from hyxi_cloud_api import HyxiApiClient
 
+from .binary_sensor import ACTIVE_ALARM_STATES
 from .const import (
     DOMAIN,
     MANUFACTURER,
@@ -56,6 +57,9 @@ async def async_setup_entry(
     entities: list[ButtonEntity] = []
 
     for sn, dev_data in coordinator.data.items():
+        # Clear Active Alarms button is available for every device SN
+        entities.append(HyxiClearAlarmsButton(coordinator, sn, dev_data))
+
         device_type = normalize_device_type(get_raw_device_code(dev_data))
 
         # Microinverter: Restart button (controlId 3013)
@@ -97,6 +101,63 @@ async def async_setup_entry(
 
     if entities:
         async_add_entities(entities)
+
+
+class HyxiClearAlarmsButton(CoordinatorEntity, ButtonEntity):
+    """Button to clear active alarms for a device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "clear_alarms"
+    _attr_icon = "mdi:bell-check-outline"
+
+    def __init__(self, coordinator, sn: str, dev_data: dict) -> None:
+        """Initialize the clear alarms button."""
+        super().__init__(coordinator)
+        self._sn = sn
+        self._attr_unique_id = f"hyxi_{sn}_clear_alarms"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, sn)},
+            "name": dev_data.get("device_name") or f"Device {sn}",
+            "manufacturer": MANUFACTURER,
+            "model": dev_data.get("model"),
+            "serial_number": sn,
+        }
+
+    async def async_press(self) -> None:
+        """Press the button to clear active alarms."""
+        client = self.coordinator.client
+        alarms = (self.coordinator.data.get(self._sn) or {}).get("alarms") or []
+
+        active_ids = []
+        for alarm in alarms:
+            alarm_state = alarm.get("alarmState")
+            if alarm_state is None:
+                alarm_state = alarm.get("alarmstate")
+            if alarm_state in ACTIVE_ALARM_STATES:
+                if alarm.get("endTime") or alarm.get("endtime"):
+                    continue
+                alarm_id = (
+                    alarm.get("id") or alarm.get("alarmId") or alarm.get("alarmid")
+                )
+                if alarm_id is not None:
+                    try:
+                        active_ids.append(int(alarm_id))
+                    except ValueError, TypeError:
+                        pass
+
+        if not active_ids:
+            _LOGGER.info("No active alarms to clear for device %s", self._sn)
+            return
+
+        try:
+            await client.alter_alarm(active_ids)
+            _LOGGER.info("Cleared active alarms %s for device %s", active_ids, self._sn)
+            await self.coordinator.async_request_refresh()
+        except HyxiApiClient.ControlError as err:
+            _LOGGER.error(
+                "Failed to clear active alarms for device %s: %s", self._sn, err
+            )
+            raise
 
 
 class HyxiMicroRestartButton(CoordinatorEntity, ButtonEntity):

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.0"
+    "hyxi-cloud-api>=1.2.1"
   ],
   "version": "1.4.0"
 }

--- a/custom_components/hyxi_cloud/strings.json
+++ b/custom_components/hyxi_cloud/strings.json
@@ -458,6 +458,9 @@
       },
       "peak_shaving_hold": {
         "name": "Hold"
+      },
+      "clear_alarms": {
+        "name": "Clear Active Alarms"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/af.json
+++ b/custom_components/hyxi_cloud/translations/af.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Hou"
+      },
+      "clear_alarms": {
+        "name": "Maak aktiewe alarms skoon"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/cs.json
+++ b/custom_components/hyxi_cloud/translations/cs.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Držet"
+      },
+      "clear_alarms": {
+        "name": "Vymazat aktivní alarmy"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/da.json
+++ b/custom_components/hyxi_cloud/translations/da.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Hold"
+      },
+      "clear_alarms": {
+        "name": "Ryd aktive alarmer"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/de.json
+++ b/custom_components/hyxi_cloud/translations/de.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Halten"
+      },
+      "clear_alarms": {
+        "name": "Aktive Alarme löschen"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/en.json
+++ b/custom_components/hyxi_cloud/translations/en.json
@@ -457,6 +457,9 @@
       },
       "peak_shaving_hold": {
         "name": "Hold"
+      },
+      "clear_alarms": {
+        "name": "Clear Active Alarms"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/es.json
+++ b/custom_components/hyxi_cloud/translations/es.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Mantener"
+      },
+      "clear_alarms": {
+        "name": "Borrar alarmas activas"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/fi.json
+++ b/custom_components/hyxi_cloud/translations/fi.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Pidä"
+      },
+      "clear_alarms": {
+        "name": "Tyhjennä aktiiviset hälytykset"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/fr.json
+++ b/custom_components/hyxi_cloud/translations/fr.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Maintien"
+      },
+      "clear_alarms": {
+        "name": "Effacer les alarmes actives"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/hu.json
+++ b/custom_components/hyxi_cloud/translations/hu.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Tartás"
+      },
+      "clear_alarms": {
+        "name": "Aktív riasztások törlése"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/it.json
+++ b/custom_components/hyxi_cloud/translations/it.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Mantenimento"
+      },
+      "clear_alarms": {
+        "name": "Cancella allarmi attivi"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/ja.json
+++ b/custom_components/hyxi_cloud/translations/ja.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "保持"
+      },
+      "clear_alarms": {
+        "name": "アクティブなアラームをクリア"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/nb.json
+++ b/custom_components/hyxi_cloud/translations/nb.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Hold"
+      },
+      "clear_alarms": {
+        "name": "Nullstill aktive alarmer"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/nl.json
+++ b/custom_components/hyxi_cloud/translations/nl.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Vasthouden"
+      },
+      "clear_alarms": {
+        "name": "Actieve alarmen wissen"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/pl.json
+++ b/custom_components/hyxi_cloud/translations/pl.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Utrzymaj"
+      },
+      "clear_alarms": {
+        "name": "Wyczyść aktywne alarmy"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/pt-BR.json
+++ b/custom_components/hyxi_cloud/translations/pt-BR.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Manter"
+      },
+      "clear_alarms": {
+        "name": "Limpar alarmes ativos"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/pt.json
+++ b/custom_components/hyxi_cloud/translations/pt.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Manter"
+      },
+      "clear_alarms": {
+        "name": "Limpar alarmes ativos"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/ru.json
+++ b/custom_components/hyxi_cloud/translations/ru.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Удержание"
+      },
+      "clear_alarms": {
+        "name": "Очистить активные аварии"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/sv.json
+++ b/custom_components/hyxi_cloud/translations/sv.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Håll"
+      },
+      "clear_alarms": {
+        "name": "Rensa aktiva larm"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/tr.json
+++ b/custom_components/hyxi_cloud/translations/tr.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "Tut"
+      },
+      "clear_alarms": {
+        "name": "Aktif alarmları temizle"
       }
     }
   }

--- a/custom_components/hyxi_cloud/translations/zh-Hans.json
+++ b/custom_components/hyxi_cloud/translations/zh-Hans.json
@@ -456,6 +456,9 @@
       },
       "peak_shaving_hold": {
         "name": "保持"
+      },
+      "clear_alarms": {
+        "name": "清除活动告警"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.2.0"
+    "hyxi-cloud-api>=1.2.1"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.0
+hyxi-cloud-api>=1.2.1
 
 # Development/Linting tools
 ruff>=0.15.13

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.7
-hyxi-cloud-api>=1.2.0
+hyxi-cloud-api>=1.2.1

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -144,12 +144,14 @@ def test_device_alarm_sensor(mock_coordinator, mock_entry):
     mock_coordinator.data["SN123"]["alarms"] = [
         {"alarmState": "1"},
         {"alarmState": 0},
+        {"alarmState": 2, "endTime": 1779374715000},  # resolved alarm, should not count
+        {"alarmState": 1, "endtime": 0},  # active alarm (endtime=0)
     ]
 
     sensor = bs_mod.HyxiDeviceAlarmSensor(mock_coordinator, mock_entry, "SN123")
 
     assert sensor.is_on is True
-    assert sensor.extra_state_attributes["active_alarms_count"] == 2
+    assert sensor.extra_state_attributes["active_alarms_count"] == 3
 
     # Test update via coordinator handle
     mock_coordinator.data["SN123"]["alarms"] = []

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -74,6 +74,7 @@ def mock_coordinator_fixture():
     coord.client.set_mode_discharge = AsyncMock()
     coord.client.set_mode_self_consume = AsyncMock()
     coord.client.set_peak_shaving = AsyncMock()
+    coord.client.alter_alarm = AsyncMock()
     coord.async_request_refresh = AsyncMock()
     return coord
 
@@ -113,9 +114,15 @@ async def test_async_setup_entry_micro_inverter(
 
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args[0][0]
-    assert len(entities) == 1
-    assert isinstance(entities[0], button_mod.HyxiMicroRestartButton)
-    assert entities[0]._sn == "SN_MICRO"
+    assert len(entities) == 2
+    assert any(isinstance(e, button_mod.HyxiClearAlarmsButton) for e in entities)
+    assert any(isinstance(e, button_mod.HyxiMicroRestartButton) for e in entities)
+    assert (
+        next(
+            e for e in entities if isinstance(e, button_mod.HyxiMicroRestartButton)
+        )._sn
+        == "SN_MICRO"
+    )
 
 
 @pytest.mark.asyncio
@@ -149,10 +156,11 @@ async def test_async_setup_entry_three_phase(
 
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args[0][0]
-    assert len(entities) == 4
-    for entity in entities:
-        assert isinstance(entity, button_mod.HyxiModeButton)
-    modes = [e._mode for e in entities]
+    assert len(entities) == 5
+    assert any(isinstance(e, button_mod.HyxiClearAlarmsButton) for e in entities)
+    mode_entities = [e for e in entities if isinstance(e, button_mod.HyxiModeButton)]
+    assert len(mode_entities) == 4
+    modes = [e._mode for e in mode_entities]
     assert sorted(modes) == ["charge", "discharge", "idle", "self_consume"]
 
 
@@ -187,10 +195,13 @@ async def test_async_setup_entry_single_phase(
 
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args[0][0]
-    assert len(entities) == 5
-    for entity in entities:
-        assert isinstance(entity, button_mod.HyxiPeakShavingButton)
-    options = [e._option for e in entities]
+    assert len(entities) == 6
+    assert any(isinstance(e, button_mod.HyxiClearAlarmsButton) for e in entities)
+    shaving_entities = [
+        e for e in entities if isinstance(e, button_mod.HyxiPeakShavingButton)
+    ]
+    assert len(shaving_entities) == 5
+    options = [e._option for e in shaving_entities]
     assert sorted(options) == ["charge", "close", "discharge", "hold", "stop"]
 
 
@@ -223,7 +234,11 @@ async def test_async_setup_entry_unknown_phase(
     ):
         await button_mod.async_setup_entry(hass, mock_entry_fixture, async_add_entities)
 
-    async_add_entities.assert_not_called()
+    # For unknown phase, the mode buttons are skipped, but the clear alarms button is still added
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], button_mod.HyxiClearAlarmsButton)
 
 
 @pytest.mark.asyncio
@@ -395,3 +410,78 @@ def test_get_power_value_invalid_state():
         # Test None state (entity missing from state machine)
         hass.states.get.return_value = None
         assert button_mod._get_power_value(hass, "SN123", "charge") == 100
+
+
+@pytest.mark.asyncio
+async def test_clear_alarms_button_press(mock_coordinator_fixture):
+    """Test pressing the clear alarms button with active alarms."""
+    # Mock some alarms in data
+    mock_coordinator_fixture.data = {
+        "SN123": {
+            "alarms": [
+                {"id": 44733168, "alarmState": 2, "alarmName": "Grid failure"},
+                {"alarmId": 44733169, "alarmstate": 1, "alarmName": "Battery failure"},
+                {
+                    "id": 44733170,
+                    "alarmState": 3,
+                    "alarmName": "Recovered/Acknowledged",
+                },  # not active
+                {"id": 44733171, "alarmState": "0", "alarmName": "Active String"},
+                {
+                    "id": 44733172,
+                    "alarmState": 2,
+                    "alarmName": "Grid failure resolved",
+                    "endTime": 1779374715000,
+                },  # resolved (has endTime), should not be cleared
+            ]
+        }
+    }
+    btn = button_mod.HyxiClearAlarmsButton(mock_coordinator_fixture, "SN123", {})
+
+    await btn.async_press()
+
+    mock_coordinator_fixture.client.alter_alarm.assert_called_once_with(
+        [44733168, 44733169, 44733171]
+    )
+    mock_coordinator_fixture.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_alarms_button_press_no_alarms(mock_coordinator_fixture):
+    """Test pressing clear alarms button with no active alarms."""
+    mock_coordinator_fixture.data = {
+        "SN123": {
+            "alarms": [
+                {
+                    "id": 44733170,
+                    "alarmState": 3,
+                    "alarmName": "Recovered/Acknowledged",
+                },
+            ]
+        }
+    }
+    btn = button_mod.HyxiClearAlarmsButton(mock_coordinator_fixture, "SN123", {})
+
+    await btn.async_press()
+
+    mock_coordinator_fixture.client.alter_alarm.assert_not_called()
+    mock_coordinator_fixture.async_request_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clear_alarms_button_error(mock_coordinator_fixture):
+    """Test error handling in clear alarms button press."""
+    mock_coordinator_fixture.data = {
+        "SN123": {
+            "alarms": [
+                {"id": 44733168, "alarmState": 2, "alarmName": "Grid failure"},
+            ]
+        }
+    }
+    mock_coordinator_fixture.client.alter_alarm.side_effect = (
+        button_mod.HyxiApiClient.ControlError("API Failure")
+    )
+    btn = button_mod.HyxiClearAlarmsButton(mock_coordinator_fixture, "SN123", {})
+
+    with pytest.raises(button_mod.HyxiApiClient.ControlError):
+        await btn.async_press()


### PR DESCRIPTION
# Description

This Pull Request integrates support for clearing/acknowledging active alarm events via the HYXI Cloud `alterAlarm` API and adds a stateless `Clear Active Alarms` button in the Home Assistant integration for every device SN. It also resolves a bug where already-resolved/ended alarms were incorrectly counted as active problems, causing the button press to fail with `C000007`.

## Summary
* Integrates `HyxiClearAlarmsButton` to allow manual clearing/acknowledging of active device alarms in Home Assistant.
* Resolves `C000007` ("Invalid response data") errors caused by calling `alterAlarm` on alarms that have already recovered/ended.
* Prevents the `device_alarm` binary sensor from staying stuck `On` (PROBLEM) after an alarm resolves.

## Key Changes
* **custom_components/hyxi_cloud/binary_sensor.py**:
  * Updated active alarm counting logic to ignore alarms where `endTime` or `endtime` is set, allowing the sensor to turn `Off` (Normal) when alarms resolve.
* **custom_components/hyxi_cloud/button.py**:
  * Added `HyxiClearAlarmsButton` to all devices.
  * Filters out alarms that have already ended/recovered to avoid sending resolved alarm IDs to the cloud API, which would return `C000007`.
  * Logs an informational message and returns early if no active, unresolved alarms are present.
* **custom_components/hyxi_cloud/manifest.json / pyproject.toml / requirements.txt / requirements_test.txt**:
  * Pin requirement to `hyxi-cloud-api>=1.2.1` to access the new `alter_alarm` endpoint.
* **custom_components/hyxi_cloud/strings.json & translations/*.json**:
  * Added translations for `"clear_alarms"` buttons in all 20 translation files.
* **tests/test_binary_sensor.py & tests/test_button.py**:
  * Added test cases to assert that resolved alarms with a set `endTime`/`endtime` are correctly ignored by the binary sensor and the clear button.

## Why this is needed
Previously, resolved/recovered alarms (such as a transient grid failure that ended) were counted as active problems in Home Assistant. Because these alarms were already marked resolved on the device and cloud side, calling `alterAlarm` on them triggered `C000007` (Invalid response data). By ignoring alarms that have resolved (`endTime` is set) in both the sensor and button platforms, we keep the HA system state aligned with the real hardware state and prevent failing API calls.
