### PR TITLE
fix: pin hyxi-cloud-api to commit SHA in tests.yml (Scorecard #80)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install git+https://github.com/Veldkornet/hyxi-cloud-api.git
+          pip install git+https://github.com/Veldkornet/hyxi-cloud-api.git@51e45d54e88ed3152d57f4aaaef5968a52073636
           pip install -r requirements_test.txt
 
       - name: Run Unit Tests


### PR DESCRIPTION
## Summary

Resolves Scorecard code-scanning alert [#80](https://github.com/Veldkornet/ha-hyxi-cloud/security/code-scanning/80) (`Pinned-Dependencies` / `pipCommand not pinned by hash`).

The CI test workflow was installing the `hyxi-cloud-api` dependency against the mutable `main` branch ref, with no integrity guarantee:

```yaml
# Before (unpinned — mutable ref)
pip install git+https://github.com/Veldkornet/hyxi-cloud-api.git
```

## Key Changes

#### [MODIFY] `.github/workflows/tests.yml`

Pin `hyxi-cloud-api` to the current HEAD commit SHA:

```yaml
# After (pinned to 40-char SHA)
pip install git+https://github.com/Veldkornet/hyxi-cloud-api.git@51e45d54e88ed3152d57f4aaaef5968a52073636
```

Pinned SHA: `51e45d54e88ed3152d57f4aaaef5968a52073636`
Commit message: _feat: Add alter_alarm endpoint support (#331)_ (2026-05-22)

## Why This Is Needed

Using a mutable branch ref (`main`) as a pip source is a supply-chain attack vector:
- A force-push or compromised commit on the upstream repo would be silently pulled into CI with full execution privileges
- There is no cryptographic integrity check — pip installs whatever is at `HEAD` at that moment

Pinning to a full 40-character SHA ensures CI always builds against a known, reviewed version of the dependency. This aligns with our **zero-trust supply-chain policy** (Rule 2: pin all dependencies by full commit hash) and matches how GitHub Actions are already pinned in this repo's workflows.

> **Note for maintainers:** When merging new `hyxi-cloud-api` releases, update the SHA here to the reviewed merge commit of the release.