### PR TITLE
fix(coordinator): handle empty telemetry gracefully

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,7 @@
-## 2025-02-21 - Memory allocations in Python default arguments\n**Learning:** Passing a dictionary or list default argument like `.get("key", {})` triggers a redundant evaluation of that object. This implies the creation and immediate deletion of an empty dictionary inside memory when the default parameter isn't used.\n**Action:** Use an explicit `or {}` instead of passing the default argument, i.e., `.get("key") or {}`.
+## 2025-02-21 - Memory allocations in Python default arguments
+**Learning:** Passing a dictionary or list default argument like `.get("key", {})` triggers a redundant evaluation of that object. This implies the creation and immediate deletion of an empty dictionary inside memory when the default parameter isn't used.
+**Action:** Use an explicit `or {}` instead of passing the default argument, i.e., `.get("key") or {}`.
+
+## 2026-05-22 - PEP 758 Exception Syntax in Python 3.14+
+**Learning:** PEP 758 (introduced in Python 3.14) allows omitting parentheses when catching multiple exceptions in `except` and `except*` clauses (e.g. `except ValueError, TypeError:`), provided the `as` clause is not used. However, this syntax is not backward-compatible and will cause syntax errors in Python 3.13 and earlier.
+**Action:** Always omit the parentheses, e.g. `except ValueError, TypeError:`, since we are using Python 3.14 runtimes.

--- a/custom_components/hyxi_cloud/coordinator.py
+++ b/custom_components/hyxi_cloud/coordinator.py
@@ -13,7 +13,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 from hyxi_cloud_api import HyxiApiClient
 
-from .const import CONF_BACK_DISCOVERY, DOMAIN, get_software_version, mask_sn
+from .const import (
+    CONF_BACK_DISCOVERY,
+    DOMAIN,
+    get_raw_device_code,
+    get_software_version,
+    mask_sn,
+    normalize_device_type,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +90,19 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
 
             # ✅ Success! Update metadata attributes.
             devices = result["data"]
+
+            # Raise UpdateFailed if all non-collector devices return empty telemetry metrics.
+            non_collectors = [
+                dev_data
+                for dev_data in devices.values()
+                if normalize_device_type(get_raw_device_code(dev_data)) != "collector"
+            ]
+            if non_collectors and all(
+                not (set(dev_data.get("metrics") or {}) - {"last_seen"})
+                for dev_data in non_collectors
+            ):
+                raise UpdateFailed("HYXI telemetry data is currently unavailable.")
+
             self.hyxi_metadata["last_attempts"] = result.get("attempts", 1)
             self.hyxi_metadata["last_success"] = dt_util.utcnow()
             self.hyxi_metadata["api_status"] = "Online"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -56,6 +56,29 @@ sys.modules["hyxi_cloud_api"] = mock_api
 
 mock_const = MagicMock()
 mock_const.DOMAIN = "hyxi_cloud"
+
+
+def real_get_raw_device_code(dev_data):
+    return (
+        dev_data.get("device_type_code")
+        or dev_data.get("deviceType")
+        or dev_data.get("devType")
+        or dev_data.get("deviceCode")
+        or ""
+    )
+
+
+def real_normalize_device_type(code):
+    if not code:
+        return "unknown"
+    code_str = str(code).upper().strip()
+    if code_str in ("3", "COLLECTOR", "DMU", "607"):
+        return "collector"
+    return "hybrid_inverter"
+
+
+mock_const.get_raw_device_code = real_get_raw_device_code
+mock_const.normalize_device_type = real_normalize_device_type
 sys.modules["custom_components.hyxi_cloud.const"] = mock_const
 
 
@@ -128,12 +151,12 @@ async def test_async_update_data_none_result():
 
 @pytest.mark.asyncio
 async def test_async_update_data_success():
-    """Test successful data update."""
+    """Test successful data update with non-empty metrics."""
     mock_entry = MagicMock()
     mock_entry.options = {"update_interval": 5}
     mock_client = MagicMock()
     mock_client.get_all_device_data = AsyncMock(
-        return_value={"data": {"SN123": {"metrics": {}}}, "attempts": 1}
+        return_value={"data": {"SN123": {"metrics": {"tinv": "45.0"}}}, "attempts": 1}
     )
 
     coordinator = hc_coord.HyxiDataUpdateCoordinator(
@@ -142,9 +165,56 @@ async def test_async_update_data_success():
 
     result = await coordinator._async_update_data()
 
-    # We only care about the metrics in this test; _sw_version_cached is added by optimization
-    assert result["SN123"]["metrics"] == {}
+    assert result["SN123"]["metrics"] == {"tinv": "45.0"}
     assert coordinator.hyxi_metadata["last_attempts"] == 1
+    assert coordinator.hyxi_metadata["last_success"] is not None
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_empty_telemetry():
+    """Test that empty telemetry raises UpdateFailed."""
+    mock_entry = MagicMock()
+    mock_entry.options = {"update_interval": 5}
+    mock_client = MagicMock()
+    # Device with empty metrics (only last_seen) should trigger UpdateFailed
+    mock_client.get_all_device_data = AsyncMock(
+        return_value={
+            "data": {"SN123": {"metrics": {"last_seen": "2026-05-22"}}},
+            "attempts": 1,
+        }
+    )
+
+    coordinator = hc_coord.HyxiDataUpdateCoordinator(
+        MagicMock(), mock_client, mock_entry
+    )
+
+    with pytest.raises(hc_coord.UpdateFailed) as excinfo:
+        await coordinator._async_update_data()
+
+    assert "HYXI telemetry data is currently unavailable." in str(excinfo.value)
+    assert coordinator.hyxi_metadata["api_status"] == "Error"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_empty_telemetry_collector_only():
+    """Test that empty metrics for collectors only does not raise UpdateFailed."""
+    mock_entry = MagicMock()
+    mock_entry.options = {"update_interval": 5}
+    mock_client = MagicMock()
+    # Device type "3" (collector) with empty metrics should NOT trigger UpdateFailed
+    mock_client.get_all_device_data = AsyncMock(
+        return_value={
+            "data": {"SN123": {"device_type_code": "3", "metrics": {}}},
+            "attempts": 1,
+        }
+    )
+
+    coordinator = hc_coord.HyxiDataUpdateCoordinator(
+        MagicMock(), mock_client, mock_entry
+    )
+
+    result = await coordinator._async_update_data()
+    assert result["SN123"]["metrics"] == {}
     assert coordinator.hyxi_metadata["last_success"] is not None
 
 


### PR DESCRIPTION
## Summary
Implements validation in the data coordinator to gracefully raise `UpdateFailed` when empty telemetry is returned by the API. This improves the situation described in issue #384.

## Key Changes
- **custom_components/hyxi_cloud/coordinator.py**: Adds a validation check after retrieving device data. If there are non-collector devices and all of them return empty telemetry metrics, an `UpdateFailed` exception is raised.
- **tests/test_coordinator.py**: Fixes `test_async_update_data_success` mock data and introduces two new tests (`test_async_update_data_empty_telemetry` and `test_async_update_data_empty_telemetry_collector_only`) validating empty telemetry responses.
- **.jules/bolt.md**: Documents PEP 758 preference for omitting parentheses under Python 3.14.

## Why this is needed
Raising `UpdateFailed` when telemetry fails ensures Home Assistant marks sensors as `unavailable` instead of losing their dynamic registration keys, allowing automatic recovery when telemetry resumes without manual integration reloads.