### PR TITLE
feat: support missing device types, batP sensor, translations, and bump version to 1.4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
             ghcr.io:443
             github.com:443
             objects.githubusercontent.com:443
+            open.hyxicloud.com:443
             pypi.org:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -8,7 +8,7 @@ CONF_SECRET_KEY = "secret_key"
 BASE_URL = "https://open.hyxicloud.com"
 
 MANUFACTURER = "HYXI Power"
-VERSION = "1.3.10"
+VERSION = "1.4.1"
 
 CONF_BACK_DISCOVERY = "back_discovery"
 
@@ -30,6 +30,11 @@ DEVICE_TYPE_KEYS = {
     "DMU": "collector",
     "COLLECTOR": "collector",
     "ALL_IN_ONE": "all_in_one",
+    "OPTIMIZER": "optimizer",
+    "METER": "meter",
+    "ENERGY_STORAGE_BATTERY": "battery",
+    "AC_BATTERY": "ac_battery",
+    "MICRO_STORAGE_ALL_IN_ONE": "micro_ess",
 }
 
 

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.1"
+    "hyxi-cloud-api>=1.2.2"
   ],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -47,6 +47,7 @@ INT_SENSOR_KEYS = {
 BATTERY_SENSORS = {
     "batSoc",
     "pbat",
+    "batP",
     "batSoh",
     "bat_charge_total",
     "bat_discharge_total",
@@ -422,6 +423,14 @@ SENSOR_TYPES = [
     ),
     SensorEntityDescription(
         key="pbat",
+        native_unit_of_measurement="W",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash",
+    ),
+    SensorEntityDescription(
+        key="batP",
+        translation_key="pbat",
         native_unit_of_measurement="W",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/hyxi_cloud/strings.json
+++ b/custom_components/hyxi_cloud/strings.json
@@ -256,6 +256,10 @@
           "micro_ess": "Micro ESS",
           "all_in_one": "All-in-One",
           "micro_inverter": "Microinverter",
+          "optimizer": "Optimizer",
+          "meter": "Meter",
+          "battery": "Battery",
+          "ac_battery": "AC Battery",
           "unknown": "Unknown"
         }
       },

--- a/custom_components/hyxi_cloud/translations/af.json
+++ b/custom_components/hyxi_cloud/translations/af.json
@@ -251,7 +251,11 @@
           "collector": "Datameter",
           "micro_ess": "Micro ESS",
           "unknown": "Onbekend",
-          "micro_inverter": "Mikro-omsetter"
+          "micro_inverter": "Mikro-omsetter",
+          "optimizer": "Optimiseerder",
+          "meter": "Meter",
+          "battery": "Battery",
+          "ac_battery": "AC-battery"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/cs.json
+++ b/custom_components/hyxi_cloud/translations/cs.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Neznámý",
-          "micro_inverter": "Mikroinvertor"
+          "micro_inverter": "Mikroinvertor",
+          "optimizer": "Optimalizátor",
+          "meter": "Elektroměr",
+          "battery": "Baterie",
+          "ac_battery": "AC baterie"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/da.json
+++ b/custom_components/hyxi_cloud/translations/da.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Ukendt",
-          "micro_inverter": "Mikroinverter"
+          "micro_inverter": "Mikroinverter",
+          "optimizer": "Optimerer",
+          "meter": "Måler",
+          "battery": "Batteri",
+          "ac_battery": "AC-batteri"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/de.json
+++ b/custom_components/hyxi_cloud/translations/de.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro-Energiespeichersystem (Micro ESS)",
           "unknown": "Unbekannt",
-          "micro_inverter": "Mikrowechselrichter"
+          "micro_inverter": "Mikrowechselrichter",
+          "optimizer": "Optimierer",
+          "meter": "Zähler",
+          "battery": "Batterie",
+          "ac_battery": "AC-Batterie"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/en.json
+++ b/custom_components/hyxi_cloud/translations/en.json
@@ -252,6 +252,10 @@
           "micro_ess": "Micro ESS",
           "all_in_one": "All-in-One",
           "micro_inverter": "Microinverter",
+          "optimizer": "Optimizer",
+          "meter": "Meter",
+          "battery": "Battery",
+          "ac_battery": "AC Battery",
           "unknown": "Unknown"
         }
       },

--- a/custom_components/hyxi_cloud/translations/es.json
+++ b/custom_components/hyxi_cloud/translations/es.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Desconocido",
-          "micro_inverter": "Microinversor"
+          "micro_inverter": "Microinversor",
+          "optimizer": "Optimizador",
+          "meter": "Medidor",
+          "battery": "Batería",
+          "ac_battery": "Batería de CA"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/fi.json
+++ b/custom_components/hyxi_cloud/translations/fi.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Tuntematon",
-          "micro_inverter": "Mikroinvertteri"
+          "micro_inverter": "Mikroinvertteri",
+          "optimizer": "Optimoija",
+          "meter": "Mittari",
+          "battery": "Akku",
+          "ac_battery": "AC-akku"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/fr.json
+++ b/custom_components/hyxi_cloud/translations/fr.json
@@ -251,7 +251,11 @@
           "collector": "Collecteur de données",
           "micro_ess": "Système de stockage d'énergie micro (Micro ESS)",
           "unknown": "Inconnu",
-          "micro_inverter": "Micro-onduleur"
+          "micro_inverter": "Micro-onduleur",
+          "optimizer": "Optimiseur",
+          "meter": "Compteur",
+          "battery": "Batterie",
+          "ac_battery": "Batterie CA"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/hu.json
+++ b/custom_components/hyxi_cloud/translations/hu.json
@@ -251,7 +251,11 @@
           "collector": "Adatgyűjtő",
           "micro_ess": "Micro ESS",
           "unknown": "Ismeretlen",
-          "micro_inverter": "Mikroinverter"
+          "micro_inverter": "Mikroinverter",
+          "optimizer": "Optimalizáló",
+          "meter": "Mérő",
+          "battery": "Akkumulátor",
+          "ac_battery": "AC akkumulátor"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/it.json
+++ b/custom_components/hyxi_cloud/translations/it.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Sconosciuto",
-          "micro_inverter": "Microinverter"
+          "micro_inverter": "Microinverter",
+          "optimizer": "Ottimizzatore",
+          "meter": "Contatore",
+          "battery": "Batteria",
+          "ac_battery": "Batteria CA"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/ja.json
+++ b/custom_components/hyxi_cloud/translations/ja.json
@@ -251,7 +251,11 @@
           "collector": "データロガー",
           "micro_ess": "マイクロESS",
           "unknown": "不明",
-          "micro_inverter": "マイクロインバーター"
+          "micro_inverter": "マイクロインバーター",
+          "optimizer": "オプティマイザ",
+          "meter": "電力量計",
+          "battery": "バッテリー",
+          "ac_battery": "ACバッテリー"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/nb.json
+++ b/custom_components/hyxi_cloud/translations/nb.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Ukjent",
-          "micro_inverter": "Mikroinverter"
+          "micro_inverter": "Mikroinverter",
+          "optimizer": "Optimerer",
+          "meter": "Måler",
+          "battery": "Batteri",
+          "ac_battery": "AC-batteri"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/nl.json
+++ b/custom_components/hyxi_cloud/translations/nl.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro-energieopslagsysteem (Micro ESS)",
           "unknown": "Onbekend",
-          "micro_inverter": "Micro-omvormer"
+          "micro_inverter": "Micro-omvormer",
+          "optimizer": "Optimalisator",
+          "meter": "Meter",
+          "battery": "Batterij",
+          "ac_battery": "AC-batterij"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/pl.json
+++ b/custom_components/hyxi_cloud/translations/pl.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Nieznany",
-          "micro_inverter": "Mikrofalownik"
+          "micro_inverter": "Mikrofalownik",
+          "optimizer": "Optymalizator",
+          "meter": "Licznik",
+          "battery": "Bateria",
+          "ac_battery": "Bateria AC"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/pt-BR.json
+++ b/custom_components/hyxi_cloud/translations/pt-BR.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Desconhecido",
-          "micro_inverter": "Microinversor"
+          "micro_inverter": "Microinversor",
+          "optimizer": "Otimizador",
+          "meter": "Medidor",
+          "battery": "Bateria",
+          "ac_battery": "Bateria CA"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/pt.json
+++ b/custom_components/hyxi_cloud/translations/pt.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Desconhecido",
-          "micro_inverter": "Microinversor"
+          "micro_inverter": "Microinversor",
+          "optimizer": "Otimizador",
+          "meter": "Medidor",
+          "battery": "Bateria",
+          "ac_battery": "Bateria CA"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/ru.json
+++ b/custom_components/hyxi_cloud/translations/ru.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Неизвестно",
-          "micro_inverter": "Микроинвертор"
+          "micro_inverter": "Микроинвертор",
+          "optimizer": "Оптимизатор",
+          "meter": "Счетчик",
+          "battery": "Батарея",
+          "ac_battery": "Батарея переменного тока"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/sv.json
+++ b/custom_components/hyxi_cloud/translations/sv.json
@@ -251,7 +251,11 @@
           "collector": "Datalogger",
           "micro_ess": "Micro ESS",
           "unknown": "Okänd",
-          "micro_inverter": "Mikroinverter"
+          "micro_inverter": "Mikroinverter",
+          "optimizer": "Optimerare",
+          "meter": "Mätare",
+          "battery": "Batteri",
+          "ac_battery": "AC-batteri"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/tr.json
+++ b/custom_components/hyxi_cloud/translations/tr.json
@@ -251,7 +251,11 @@
           "collector": "Veri Toplayıcı",
           "micro_ess": "Mikro ESS",
           "unknown": "Bilinmiyor",
-          "micro_inverter": "Mikro İnvertör"
+          "micro_inverter": "Mikro İnvertör",
+          "optimizer": "Optimizör",
+          "meter": "Sayaç",
+          "battery": "Batarya",
+          "ac_battery": "AC Batarya"
         }
       },
       "ratedpower": {

--- a/custom_components/hyxi_cloud/translations/zh-Hans.json
+++ b/custom_components/hyxi_cloud/translations/zh-Hans.json
@@ -251,7 +251,11 @@
           "collector": "数据采集器",
           "micro_ess": "微型储能",
           "unknown": "未知",
-          "micro_inverter": "微型逆变器"
+          "micro_inverter": "微型逆变器",
+          "optimizer": "优化器",
+          "meter": "电表",
+          "battery": "电池",
+          "ac_battery": "交流电池"
         }
       },
       "ratedpower": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.1
+hyxi-cloud-api>=1.2.2
 
 # Development/Linting tools
 ruff>=0.15.13

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.7
-hyxi-cloud-api>=1.2.1
+hyxi-cloud-api>=1.2.2
 pytest-homeassistant-custom-component>=0.13.332

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -46,6 +46,11 @@ def test_normalize_device_type():
     assert normalize_device_type("EMS") == "micro_ess"
     assert normalize_device_type("COLLECTOR") == "collector"
     assert normalize_device_type("MICRO_INVERTER") == "micro_inverter"
+    assert normalize_device_type("OPTIMIZER") == "optimizer"
+    assert normalize_device_type("METER") == "meter"
+    assert normalize_device_type("ENERGY_STORAGE_BATTERY") == "battery"
+    assert normalize_device_type("AC_BATTERY") == "ac_battery"
+    assert normalize_device_type("MICRO_STORAGE_ALL_IN_ONE") == "micro_ess"
 
     # 6. Substring match (if API returned a name instead of code)
     assert normalize_device_type("SOME_COLLECTOR") == "collector"

--- a/tests/test_sensor_logic.py
+++ b/tests/test_sensor_logic.py
@@ -984,6 +984,7 @@ async def test_new_telemetry_keys_registration_and_parsing():
                 "batDisCharge": "12.3",  # float (battery)
                 "totalEchg": "1500.5",  # float (battery)
                 "totalEdchg": "1200.2",  # float (battery)
+                "batP": "150.7",  # float (battery)
                 "ratedFrequency": "50",  # integer (from queryDeviceInfo)
                 "batSn": "BAT_REAL_123",
             },
@@ -1037,6 +1038,7 @@ async def test_new_telemetry_keys_registration_and_parsing():
         "batDisCharge",
         "totalEchg",
         "totalEdchg",
+        "batP",
         "ratedFrequency",
     ]
 
@@ -1055,6 +1057,7 @@ async def test_new_telemetry_keys_registration_and_parsing():
     assert registered_by_key["pvNum"].native_value == 4
     assert registered_by_key["acSideTemper"].native_value == 45.2
     assert registered_by_key["dcSideTemper"].native_value == 50.1
+    assert registered_by_key["batP"].native_value == 150.7
 
     # Verify battery SN routing
     battery_keys = [
@@ -1068,6 +1071,7 @@ async def test_new_telemetry_keys_registration_and_parsing():
         "batDisCharge",
         "totalEchg",
         "totalEdchg",
+        "batP",
     ]
     for key in battery_keys:
         sensor_entity = registered_by_key[key]


### PR DESCRIPTION
# Summary
Add support for missing official HYXI device types, map the `batP` battery power sensor key, generate translations across all 20 supported languages, and bump the integration version to `1.4.1` requiring `hyxi-cloud-api>=1.2.2`.

# Key Changes
- Added support for missing device types (`OPTIMIZER`, `METER`, `ENERGY_STORAGE_BATTERY`, `AC_BATTERY`, and `MICRO_STORAGE_ALL_IN_ONE` as `micro_ess`) to the `DEVICE_TYPE_KEYS` map in `const.py`.
- Added the `batP` raw battery power sensor mapping to `sensor.py`, referencing the `pbat` translation key.
- Populated the state translation strings for the four new device types in all 20 translation files.
- Bumped integration version to `1.4.1` in `const.py` and `manifest.json` and updated requirement to `hyxi-cloud-api>=1.2.2`.
- Added unit tests verifying `batP` registration, routing, and normalization in `tests/test_sensor_logic.py` and `tests/test_const.py`.

# Why this is needed
This resolves issues where certain device types showed up as "Unknown" or normalized incorrectly, registers the missing battery power sensor, and keeps translations and versions fully synchronized.