### PR TITLE
Fix device SN masking mismatch and log metrics keys & values (v1.4.2)

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -8,7 +8,7 @@ CONF_SECRET_KEY = "secret_key"
 BASE_URL = "https://open.hyxicloud.com"
 
 MANUFACTURER = "HYXI Power"
-VERSION = "1.4.1"
+VERSION = "1.4.2"
 
 CONF_BACK_DISCOVERY = "back_discovery"
 
@@ -39,17 +39,16 @@ DEVICE_TYPE_KEYS = {
 
 
 def mask_sn(sn: str) -> str:
-    """Mask a serial number for logs, masking all but the last 4 chars with X.
+    """Mask a serial number/identifier securely using SHA-256 (first 8 chars) to match API library.
 
     Matches the _mask_id format used in the API library.
     """
-    if not sn:
+    import hashlib
+
+    if not sn or str(sn) == "None":
         return "****"
     sn_str = str(sn)
-    if len(sn_str) < 8:
-        return "****"
-    mask_len = len(sn_str) - 4
-    return f"{'X' * mask_len}{sn_str[-4:]}"
+    return hashlib.sha256(sn_str.encode("utf-8")).hexdigest()[:8]
 
 
 def get_raw_device_code(dev_data: dict) -> str:

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -16,5 +16,5 @@
     "aiohttp>=3.13.4",
     "hyxi-cloud-api>=1.2.2"
   ],
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -834,11 +834,38 @@ async def async_setup_entry(hass, entry, async_add_entities):
         device_type = normalize_device_type(raw_code)
         metrics = dev_data.get("metrics") or {}
 
+        logged_metrics = {
+            k: (
+                mask_sn(str(v))
+                if k
+                in {
+                    "deviceSn",
+                    "parentSn",
+                    "batSn",
+                    "emsSn",
+                    "alias",
+                    "plantId",
+                    "gprsImei",
+                    "plantAddress",
+                    "plantName",
+                    "deviceName",
+                    "alarmName",
+                    "token",
+                    "access_token",
+                    "refresh_token",
+                    "password",
+                }
+                and v is not None
+                else v
+            )
+            for k, v in metrics.items()
+        }
+
         _LOGGER.debug(
-            "HYXI Processing Device %s (Normalized Type: %s). Metrics keys: %s",
+            "HYXI Processing Device %s (Normalized Type: %s). Metrics: %s",
             mask_sn(sn),
             device_type,
-            list(metrics.keys()),
+            logged_metrics,
         )
 
         is_collector_or_dmu = device_type == "collector"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-hyxi-cloud"
-version = "1.4.0"
+version = "1.4.2"
 description = "HYXI ⚡️🔋☀️ Integration for HomeAssistant using HYXI Cloud ☁️"
 readme = "README.md"
 authors = [

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -12,12 +12,12 @@ from custom_components.hyxi_cloud.const import (
 def test_mask_sn():
     """Verify mask_sn correctly obscures serial numbers."""
     # 1. Normal SN (8+ chars)
-    assert mask_sn("12345678") == "XXXX5678"
-    assert mask_sn("SN123456789") == "XXXXXXX6789"
+    assert mask_sn("12345678") == "ef797c81"
+    assert mask_sn("SN123456789") == "c90391cf"
 
-    # 2. Short SN (< 8 chars)
-    assert mask_sn("1234567") == "****"
-    assert mask_sn("123") == "****"
+    # 2. Short SN (< 8 chars) are now hashed too to match API library
+    assert mask_sn("1234567") == "8bb0cf6e"
+    assert mask_sn("123") == "a665a459"
 
     # 3. Empty or None
     assert mask_sn("") == "****"

--- a/tests/test_sensor_logic.py
+++ b/tests/test_sensor_logic.py
@@ -135,16 +135,16 @@ def test_mask_sn():
     assert mask_sn("") == "****"
 
     # Short string handling
-    assert mask_sn("1234567") == "****"
+    assert mask_sn("1234567") == "8bb0cf6e"
 
     # Exact length of 8
-    assert mask_sn("12345678") == "XXXX5678"
+    assert mask_sn("12345678") == "ef797c81"
 
     # Longer string
-    assert mask_sn("1234567890") == "XXXXXX7890"
+    assert mask_sn("1234567890") == "c775e7b7"
 
     # Integer values
-    assert mask_sn(12345678) == "XXXX5678"
+    assert mask_sn(12345678) == "ef797c81"
 
 
 def test_anti_dip_recovery(base_sensor):


### PR DESCRIPTION
### Summary
Aligns serial number/identifier masking between the Home Assistant integration and the underlying `hyxi_cloud_api` library to use consistent SHA-256 hashing. Enhances telemetry debugging by logging metric values alongside their keys while protecting sensitive fields using a secure, unified logging filter. Bumped version to 1.4.2.

### Key Changes
- Updated `mask_sn` helper in `custom_components/hyxi_cloud/const.py` to use `hashlib.sha256` (first 8 characters) format to mirror `_mask_id` in the API.
- Replaced `Metrics keys` list output in `custom_components/hyxi_cloud/sensor.py` with sanitized dict containing both metrics keys and values.
- Explicitly filtered/masked sensitive identifiers in logged metrics (`deviceSn`, `parentSn`, `batSn`, etc.).
- Adjusted test suites `test_const.py` and `test_sensor_logic.py` to assert the correct SHA-256 prefixes instead of the old `XXXX` masking.
- Bumped integration version to 1.4.2 in `const.py`, `manifest.json`, and `pyproject.toml`.

### Why this is needed
Allows deterministic cross-correlation of logs between the Home Assistant integration and the raw API calls without leaking any sensitive device or plant information in logs, facilitating better diagnostic and debugging capacity.