### PR TITLE
🧪 Add missing edge case tests for Switch Platform

### DIFF
--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -301,3 +301,65 @@ async def test_micro_power_switch_error(mock_coordinator_fixture):
 
     with pytest.raises(switch_mod.HyxiApiClient.ControlError):
         await switch.async_turn_off()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_all_in_one(
+    mock_coordinator_fixture, mock_entry_fixture
+):
+    """Test setup for single-phase all-in-one inverter."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {mock_entry_fixture.entry_id: mock_coordinator_fixture}}
+    mock_coordinator_fixture.data = {"SN_AIO_1": {"device_type_code": "ALL_IN_ONE"}}
+
+    async_add_entities = MagicMock()
+
+    with (
+        patch(
+            "custom_components.hyxi_cloud.switch.normalize_device_type",
+            return_value="all_in_one",
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.get_raw_device_code",
+            return_value="ALL_IN_ONE",
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.detect_phase_type",
+            return_value="single_phase",
+        ),
+    ):
+        await switch_mod.async_setup_entry(hass, mock_entry_fixture, async_add_entities)
+
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], switch_mod.HyxiFrequencyControlSwitch)
+    assert entities[0]._sn == "SN_AIO_1"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_unknown_device_type(
+    mock_coordinator_fixture, mock_entry_fixture
+):
+    """Test setup for an unknown device type."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {mock_entry_fixture.entry_id: mock_coordinator_fixture}}
+    mock_coordinator_fixture.data = {
+        "SN_UNKNOWN_1": {"device_type_code": "UNKNOWN_DEVICE"}
+    }
+
+    async_add_entities = MagicMock()
+
+    with (
+        patch(
+            "custom_components.hyxi_cloud.switch.normalize_device_type",
+            return_value="unknown",
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.get_raw_device_code",
+            return_value="UNKNOWN_DEVICE",
+        ),
+    ):
+        await switch_mod.async_setup_entry(hass, mock_entry_fixture, async_add_entities)
+
+    async_add_entities.assert_not_called()


### PR DESCRIPTION
🎯 **What:** Added tests for the `all_in_one` device type and `unknown` device types to `tests/test_switch.py`.
📊 **Coverage:** The test suite now directly covers how `async_setup_entry` treats devices identified as `all_in_one` (creates `HyxiFrequencyControlSwitch`) and those identified as `unknown` (aborts early without creating entities).
✨ **Result:** Enhanced test stability and ensured all code paths in `custom_components/hyxi_cloud/switch.py` are explicitly tested and verified in our localized testing matrix.

---
*PR created automatically by Jules for task [11512496973419780157](https://jules.google.com/task/11512496973419780157) started by @Veldkornet*