### PR TITLE
Upgrade to hyxi-cloud-api v1.2.3 and use set_micro_power

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.2"
+    "hyxi-cloud-api>=1.2.3"
   ],
   "version": "1.4.2"
 }

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -113,7 +113,7 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
         """Turn on the microinverter."""
         client = self.coordinator.client
         try:
-            await client.set_micro_power_on(self._sn)
+            await client.set_micro_power(self._sn, power_on=True)
             self._attr_is_on = True
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
@@ -125,7 +125,7 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
         """Turn off the microinverter."""
         client = self.coordinator.client
         try:
-            await client.set_micro_power_off(self._sn)
+            await client.set_micro_power(self._sn, power_on=False)
             self._attr_is_on = False
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.2.1"
+    "hyxi-cloud-api>=1.2.3"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.2
+hyxi-cloud-api>=1.2.3
 
 # Development/Linting tools
 ruff>=0.15.14

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.9
-hyxi-cloud-api>=1.2.2
+hyxi-cloud-api>=1.2.3
 pytest-homeassistant-custom-component>=0.13.333

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -84,3 +84,22 @@ def test_hyxi_entity_initialization_with_falsy_name():
         "model": "Basic",
         "serial_number": sn,
     }
+
+
+def test_hyxi_entity_initialization_with_falsy_model():
+    """Test entity initialization with falsy model name."""
+    coordinator = MagicMock()
+    sn = "888888"
+    dev_data = {"device_name": "Test Inverter", "model": ""}
+
+    entity = HyxiEntity(coordinator, sn, dev_data)
+
+    assert entity._sn == sn
+    assert getattr(entity, "_attr_has_entity_name", None) is True
+    assert entity._attr_device_info == {
+        "identifiers": {(DOMAIN, sn)},
+        "name": "Test Inverter",
+        "manufacturer": MANUFACTURER,
+        "model": "",
+        "serial_number": sn,
+    }

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -56,8 +56,7 @@ def mock_coordinator_fixture():
     coordinator.data = {}
     coordinator.client = MagicMock()
     coordinator.client.set_frequency_control = AsyncMock()
-    coordinator.client.set_micro_power_on = AsyncMock()
-    coordinator.client.set_micro_power_off = AsyncMock()
+    coordinator.client.set_micro_power = AsyncMock()
     # Ensure async methods are awaitable
     coordinator.async_request_refresh = AsyncMock()
     return coordinator
@@ -258,7 +257,9 @@ async def test_micro_power_switch_turn_on(mock_coordinator_fixture):
 
     await switch.async_turn_on()
 
-    mock_coordinator_fixture.client.set_micro_power_on.assert_called_once_with("SN123")
+    mock_coordinator_fixture.client.set_micro_power.assert_called_once_with(
+        "SN123", power_on=True
+    )
     assert switch._attr_is_on is True
     switch.async_write_ha_state.assert_called_once()
     mock_coordinator_fixture.async_request_refresh.assert_called_once()
@@ -272,7 +273,9 @@ async def test_micro_power_switch_turn_off(mock_coordinator_fixture):
 
     await switch.async_turn_off()
 
-    mock_coordinator_fixture.client.set_micro_power_off.assert_called_once_with("SN123")
+    mock_coordinator_fixture.client.set_micro_power.assert_called_once_with(
+        "SN123", power_on=False
+    )
     assert switch._attr_is_on is False
     switch.async_write_ha_state.assert_called_once()
     mock_coordinator_fixture.async_request_refresh.assert_called_once()
@@ -284,7 +287,7 @@ async def test_micro_power_switch_error(mock_coordinator_fixture):
     switch = switch_mod.HyxiMicroPowerSwitch(mock_coordinator_fixture, "SN123", {})
     switch.async_write_ha_state = MagicMock()
 
-    mock_coordinator_fixture.client.set_micro_power_on.side_effect = (
+    mock_coordinator_fixture.client.set_micro_power.side_effect = (
         switch_mod.HyxiApiClient.ControlError("Network error")
     )
 
@@ -294,10 +297,6 @@ async def test_micro_power_switch_error(mock_coordinator_fixture):
     switch.async_write_ha_state.assert_not_called()
     mock_coordinator_fixture.async_request_refresh.assert_not_called()
     assert switch._attr_is_on is None
-
-    mock_coordinator_fixture.client.set_micro_power_off.side_effect = (
-        switch_mod.HyxiApiClient.ControlError("Network error")
-    )
 
     with pytest.raises(switch_mod.HyxiApiClient.ControlError):
         await switch.async_turn_off()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -300,3 +300,65 @@ async def test_micro_power_switch_error(mock_coordinator_fixture):
 
     with pytest.raises(switch_mod.HyxiApiClient.ControlError):
         await switch.async_turn_off()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_all_in_one(
+    mock_coordinator_fixture, mock_entry_fixture
+):
+    """Test setup for single-phase all-in-one inverter."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {mock_entry_fixture.entry_id: mock_coordinator_fixture}}
+    mock_coordinator_fixture.data = {"SN_AIO_1": {"device_type_code": "ALL_IN_ONE"}}
+
+    async_add_entities = MagicMock()
+
+    with (
+        patch(
+            "custom_components.hyxi_cloud.switch.normalize_device_type",
+            return_value="all_in_one",
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.get_raw_device_code",
+            return_value="ALL_IN_ONE",
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.detect_phase_type",
+            return_value="single_phase",
+        ),
+    ):
+        await switch_mod.async_setup_entry(hass, mock_entry_fixture, async_add_entities)
+
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], switch_mod.HyxiFrequencyControlSwitch)
+    assert entities[0]._sn == "SN_AIO_1"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_unknown_device_type(
+    mock_coordinator_fixture, mock_entry_fixture
+):
+    """Test setup for an unknown device type."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {mock_entry_fixture.entry_id: mock_coordinator_fixture}}
+    mock_coordinator_fixture.data = {
+        "SN_UNKNOWN_1": {"device_type_code": "UNKNOWN_DEVICE"}
+    }
+
+    async_add_entities = MagicMock()
+
+    with (
+        patch(
+            "custom_components.hyxi_cloud.switch.normalize_device_type",
+            return_value="unknown",
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.get_raw_device_code",
+            return_value="UNKNOWN_DEVICE",
+        ),
+    ):
+        await switch_mod.async_setup_entry(hass, mock_entry_fixture, async_add_entities)
+
+    async_add_entities.assert_not_called()


### PR DESCRIPTION
### Summary
Upgrades the integration to use the unified `set_micro_power` method from `hyxi-cloud-api` version `1.2.3` and bumps the library dependency.

### Key Changes
- Updated `custom_components/hyxi_cloud/switch.py` to invoke the refactored `set_micro_power` method on the API client.
- Adjusted switch unit tests in `tests/test_switch.py` to assert the correct arguments.
- Bumped `hyxi-cloud-api` to version `>=1.2.3` in `manifest.json`, `pyproject.toml`, `requirements.txt`, and `requirements_test.txt`.

### Why this is needed
Aligns the Home Assistant integration with the updated API client library in v1.2.3, removing deprecated wrappers and ensuring compatibility.