### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -84,3 +84,22 @@ def test_hyxi_entity_initialization_with_falsy_name():
         "model": "Basic",
         "serial_number": sn,
     }
+
+
+def test_hyxi_entity_initialization_with_none_name():
+    """Test entity initialization with None device name."""
+    coordinator = MagicMock()
+    sn = "888888"
+    dev_data = {"device_name": None, "model": None}
+
+    entity = HyxiEntity(coordinator, sn, dev_data)
+
+    assert entity._sn == sn
+    assert getattr(entity, "_attr_has_entity_name", None) is True
+    assert entity._attr_device_info == {
+        "identifiers": {(DOMAIN, sn)},
+        "name": f"Device {sn}",
+        "manufacturer": MANUFACTURER,
+        "model": None,
+        "serial_number": sn,
+    }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `tests/test_entity.py` test suite lacked coverage for the specific edge case where `dev_data` contains a `None` value for `device_name`.

📊 **Coverage:** What scenarios are now tested
Added `test_hyxi_entity_initialization_with_none_name` to explicitly test that when `dev_data` has a `None` value for `device_name` (e.g. `{"device_name": None, "model": None}`), the `HyxiEntity` class safely falls back to using `f"Device {sn}"`.

✨ **Result:** The improvement in test coverage
The test coverage for `HyxiEntity` is robust and explicitly handles all falsey and missing data paths, increasing the reliability of the codebase.

---
*PR created automatically by Jules for task [17211472452946989507](https://jules.google.com/task/17211472452946989507) started by @Veldkornet*