### PR TITLE
🔒 fix: mask device serial numbers in switch platform logs

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -165,7 +165,7 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -165,7 +165,7 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -12,6 +12,7 @@ from .const import (
     DOMAIN,
     detect_phase_type,
     get_raw_device_code,
+    mask_sn,
     normalize_device_type,
 )
 from .entity import HyxiEntity
@@ -74,7 +75,7 @@ class HyxiFrequencyControlSwitch(HyxiEntity, SwitchEntity):
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
             _LOGGER.error(
-                "Failed to enable frequency control for %s: %s", self._sn, err
+                "Failed to enable frequency control for %s: %s", mask_sn(self._sn), err
             )
             raise
 
@@ -88,7 +89,7 @@ class HyxiFrequencyControlSwitch(HyxiEntity, SwitchEntity):
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
             _LOGGER.error(
-                "Failed to disable frequency control for %s: %s", self._sn, err
+                "Failed to disable frequency control for %s: %s", mask_sn(self._sn), err
             )
             raise
 
@@ -118,7 +119,9 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
-            _LOGGER.error("Failed to power on microinverter %s: %s", self._sn, err)
+            _LOGGER.error(
+                "Failed to power on microinverter %s: %s", mask_sn(self._sn), err
+            )
             raise
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -130,5 +133,7 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
-            _LOGGER.error("Failed to power off microinverter %s: %s", self._sn, err)
+            _LOGGER.error(
+                "Failed to power off microinverter %s: %s", mask_sn(self._sn), err
+            )
             raise


### PR DESCRIPTION
The switch.py file was exposing raw, unmasked device serial numbers in _LOGGER.error messages when switch actions (like micro_power on/off or frequency_control) failed. 

This commit imports `mask_sn` from `.const` and wraps all instances of `self._sn` in logging calls within `switch.py` with `mask_sn()`, protecting user data from leaking into Home Assistant logs. This follows the same security pattern already implemented in `button.py`.

---
*PR created automatically by Jules for task [16669069422201946723](https://jules.google.com/task/16669069422201946723) started by @Veldkornet*