### PR TITLE
🧪 [Testing] Mock _process_numeric_value and handle OverflowError in sensor parser tests

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -165,7 +165,10 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except ValueError, TypeError:
+        except (
+            ValueError,
+            TypeError,
+        ):
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -1164,6 +1164,7 @@ class HyxiSensor(HyxiBaseSensor):
         except (
             ValueError,
             TypeError,
+            OverflowError,
         ):
             return self._process_numeric_value(value)
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -115,13 +115,21 @@ def test_parse_int_sensor_null_equivalents(mock_sensor):
 
 def test_parse_int_sensor_error_fallback(mock_sensor):
     """Test _parse_int_sensor fallback to _process_numeric_value on error."""
-    # Invalid string
-    # _process_numeric_value for non-total_increasing sensor returns the value as is if float() fails
-    assert mock_sensor._parse_int_sensor({}, "invalid") == "invalid"
+    with patch.object(
+        mock_sensor, "_process_numeric_value", return_value="mocked_fallback"
+    ) as mock_fallback:
+        # Invalid string triggers ValueError in float()
+        assert mock_sensor._parse_int_sensor({}, "invalid") == "mocked_fallback"
+        mock_fallback.assert_called_with("invalid")
 
-    # Invalid type
-    obj = {"data": 123}
-    assert mock_sensor._parse_int_sensor({}, obj) == obj
+        # Invalid type triggers TypeError in float()
+        obj = {"data": 123}
+        assert mock_sensor._parse_int_sensor({}, obj) == "mocked_fallback"
+        mock_fallback.assert_called_with(obj)
+
+        # Overflow Error triggers OverflowError in int()
+        assert mock_sensor._parse_int_sensor({}, "inf") == "mocked_fallback"
+        mock_fallback.assert_called_with("inf")
 
 
 def test_parse_collect_time_valid(mock_sensor):


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `test_parse_int_sensor_error_fallback` test previously verified the fallback logic by checking if the input value was returned as-is, relying implicitly on the side effects of `_process_numeric_value`. Additionally, `_parse_int_sensor` crashed with an `OverflowError` when attempting to cast parsed `inf` values to `int`.

📊 **Coverage:** What scenarios are now tested
- Mocked `_process_numeric_value` using `patch.object` to explicitly assert that the fallback is invoked and receives the correct arguments when `ValueError` or `TypeError` are thrown.
- Handled `OverflowError` inside `_parse_int_sensor` and added a test case specifically ensuring `"inf"` correctly triggers the fallback.

✨ **Result:** The improvement in test coverage
The test is now robust, deterministic, and isolated from the internal logic of `_process_numeric_value`. `_parse_int_sensor` is safer and no longer crashes when receiving float infinities. Code remains compliant with PEP-758 syntax for Python 3.14+.

---
*PR created automatically by Jules for task [4910854138716681542](https://jules.google.com/task/4910854138716681542) started by @Veldkornet*