### PR TITLE
🔒 Fix remaining unmasked serial numbers in logs

### DIFF
--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -16,6 +16,7 @@ from .const import (
     MANUFACTURER,
     detect_phase_type,
     get_raw_device_code,
+    mask_sn,
     normalize_device_type,
 )
 
@@ -162,7 +163,7 @@ class HyxiMicroPowerLimit(CoordinatorEntity, NumberEntity, RestoreEntity):
             _LOGGER.error(
                 "Failed to set power limit to %d%% for %s: %s",
                 int(value),
-                self._sn,
+                mask_sn(self._sn),
                 err,
             )
             raise

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -12,6 +12,7 @@ from .const import (
     DOMAIN,
     detect_phase_type,
     get_raw_device_code,
+    mask_sn,
     normalize_device_type,
 )
 from .entity import HyxiEntity
@@ -74,7 +75,7 @@ class HyxiFrequencyControlSwitch(HyxiEntity, SwitchEntity):
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
             _LOGGER.error(
-                "Failed to enable frequency control for %s: %s", self._sn, err
+                "Failed to enable frequency control for %s: %s", mask_sn(self._sn), err
             )
             raise
 
@@ -88,7 +89,7 @@ class HyxiFrequencyControlSwitch(HyxiEntity, SwitchEntity):
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
             _LOGGER.error(
-                "Failed to disable frequency control for %s: %s", self._sn, err
+                "Failed to disable frequency control for %s: %s", mask_sn(self._sn), err
             )
             raise
 
@@ -118,7 +119,9 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
-            _LOGGER.error("Failed to power on microinverter %s: %s", self._sn, err)
+            _LOGGER.error(
+                "Failed to power on microinverter %s: %s", mask_sn(self._sn), err
+            )
             raise
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -130,5 +133,7 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
-            _LOGGER.error("Failed to power off microinverter %s: %s", self._sn, err)
+            _LOGGER.error(
+                "Failed to power off microinverter %s: %s", mask_sn(self._sn), err
+            )
             raise


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is unmasked device serial numbers being exposed in Home Assistant logs when logging API errors in `switch.py` and `number.py`.
⚠️ **Risk:** The potential impact if left unfixed is exposure of sensitive user data (device serial numbers) into external logs, violating user privacy.
🛡️ **Solution:** How the fix addresses the vulnerability is by importing and wrapping the serial numbers with `mask_sn()` before logging them, successfully obfuscating sensitive strings.

---
*PR created automatically by Jules for task [5200637669437416060](https://jules.google.com/task/5200637669437416060) started by @Veldkornet*