### PR TITLE
style: modernize exception handling with PEP 758 parenthesis-less syntax

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -113,10 +113,7 @@ def normalize_device_type(code: str | int | float) -> str:
     if "." in code_str:
         try:
             lookup_key = str(int(float(code_str)))
-        except (
-            ValueError,
-            TypeError,
-        ):
+        except ValueError, TypeError:
             # If float conversion fails (e.g. string labels), just use original code_str
             pass
 
@@ -175,10 +172,7 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except (
-            ValueError,
-            TypeError,
-        ):
+        except ValueError, TypeError:
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -924,10 +924,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                 try:
                     self._last_valid_value = float(last_state.state)
                     self._update_native_value()
-                except (
-                    ValueError,
-                    TypeError,
-                ):
+                except ValueError, TypeError:
                     _LOGGER.debug(
                         "HYXI Restore: Could not parse restored state '%s' for %s",
                         last_state.state,
@@ -1006,10 +1003,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                         return spike_result
             self._last_valid_value = num_value
             return num_value
-        except (
-            ValueError,
-            TypeError,
-        ):
+        except ValueError, TypeError:
             return value
 
 
@@ -1144,10 +1138,7 @@ class HyxiSensor(HyxiBaseSensor):
 
         try:
             return float(val)
-        except (
-            ValueError,
-            TypeError,
-        ):
+        except ValueError, TypeError:
             return None
 
     def _parse_device_type(self, dev_data, value):
@@ -1158,11 +1149,7 @@ class HyxiSensor(HyxiBaseSensor):
             return None
         try:
             return int(round(float(value), 0))
-        except (
-            ValueError,
-            TypeError,
-            OverflowError,
-        ):
+        except ValueError, TypeError, OverflowError:
             return self._process_numeric_value(value)
 
     def _parse_collect_time(self, dev_data, value):
@@ -1173,12 +1160,7 @@ class HyxiSensor(HyxiBaseSensor):
             if val_int > 9999999999:
                 val_int = val_int // 1000
             return datetime.fromtimestamp(val_int, tz=UTC)
-        except (
-            ValueError,
-            TypeError,
-            OSError,
-            OverflowError,
-        ):
+        except ValueError, TypeError, OSError, OverflowError:
             return None
 
     def _parse_last_seen(self, dev_data, value):


### PR DESCRIPTION
### Summary
Modernize all remaining multiple exception catches in `ha-hyxi-cloud` to use the unparenthesized syntax allowed under PEP 758 (available in Python 3.14+).

### Key Changes
- **`custom_components/hyxi_cloud/const.py`**: Removed parentheses from two exception catches (`ValueError, TypeError`).
- **`custom_components/hyxi_cloud/sensor.py`**: Removed parentheses from five exception catches (`ValueError, TypeError`, `ValueError, TypeError, OverflowError`, and `ValueError, TypeError, OSError, OverflowError`).

### Why this is needed
To ensure syntactic consistency across the integration, utilizing the Python 3.14+ capabilities defined under PEP 758, since the project's minimum required version is Python 3.14+.