### PR TITLE
🔧 Configure pytest to ignore integration tests by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ include = ["custom_components*"]
 pythonpath = ["."]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+addopts = "--ignore=tests/integration"
 
 [tool.pylint.similarities]
 min-similarity-lines = 100


### PR DESCRIPTION
## Summary
Configure pytest to ignore integration tests by default when running without target arguments. This resolves a known issue where unit test module-level mocks pollute `sys.modules`, breaking integration test execution in environments like the IDE's built-in test runner or plain local `pytest` runs.

## Key Changes
- Modified `pyproject.toml` to add `addopts = "--ignore=tests/integration"` under `[tool.pytest.ini_options]`.
- Verified that explicit targeting of integration tests (e.g. `pytest tests/integration`) still overrides this default and runs normally, ensuring no disruption to local terminal workflows or GitHub Actions CI runs.

## Why this is needed
In Python, once a module has been imported and mocked globally at the module level (which the unit tests do to isolate themselves from Home Assistant's dependencies), it cannot easily be reverted in the same process. This causes the integration tests (which need the real package) to fail on `AttributeError` or `UnknownHandler` when executed together under a single test session. Restricting default collection to unit tests enables a green out-of-the-box local developer experience (e.g. within Antigravity's tests tab) while preserving full CI verification on PRs.