### PR TITLE
🔧 CI: bump hyxi-cloud-api to v1.2.4 and add local test-integration command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install git+https://github.com/Veldkornet/hyxi-cloud-api.git@51e45d54e88ed3152d57f4aaaef5968a52073636
+          pip install git+https://github.com/Veldkornet/hyxi-cloud-api.git@01dd3845da6a249045728efe8fedb36ae808ae02 # v1.2.4
           pip install -r requirements_test.txt
 
       - name: Run Unit Tests

--- a/dev_env/manage.sh
+++ b/dev_env/manage.sh
@@ -114,8 +114,13 @@ case "$ACTION" in
     cd .. || exit 1
     python3 -m pre_commit run --all-files --color never
     ;;
+  test-integration)
+    echo "🧪 Running Integration Tests..."
+    cd .. || exit 1
+    HYXI_INTEGRATION_TEST="1" python3 -m pytest tests/integration -v -p no:warnings
+    ;;
   *)
-    printf "Usage: %s {start|stop|restart|ruff-check|ruff-format|ruff-fix|lint}\n" "$0"
+    printf "Usage: %s {start|stop|restart|ruff-check|ruff-format|ruff-fix|lint|test-integration}\n" "$0"
     exit 1
     ;;
 


### PR DESCRIPTION
## Summary
Bump `hyxi-cloud-api` pinned version in CI workflow to the latest release (`v1.2.4`) and configure local scripting shortcuts to run integration tests locally.

## Key Changes
- Updated pinned commit for `hyxi-cloud-api` in `.github/workflows/tests.yml` to `01dd3845da6a249045728efe8fedb36ae808ae02` and annotated it with `# v1.2.4`.
- Added the `test-integration` command to `dev_env/manage.sh`.
- Added the `Test: Run Integration Tests` task to `.vscode/tasks.json` (which remains local and excluded from git pollution via the assume-unchanged flag).

## Why this is needed
Ensures that the CI runs tests against the latest upstream release of `hyxi-cloud-api` (`v1.2.4`), keeping API client integrations in sync. Additionally, providing local scripting shortcuts allows developers to easily trigger integration tests locally without manually typing the full pytest parameters.