### PR TITLE
chore: bump version to 1.4.3

### DIFF
--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -10,7 +10,7 @@ CONF_SECRET_KEY = "secret_key"
 BASE_URL = "https://open.hyxicloud.com"
 
 MANUFACTURER = "HYXI Power"
-VERSION = "1.4.2"
+VERSION = "1.4.3"
 
 CONF_BACK_DISCOVERY = "back_discovery"
 

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -16,5 +16,5 @@
     "aiohttp>=3.13.4",
     "hyxi-cloud-api>=1.2.4"
   ],
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-hyxi-cloud"
-version = "1.4.2"
+version = "1.4.3"
 description = "HYXI ⚡️🔋☀️ Integration for HomeAssistant using HYXI Cloud ☁️"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
# Summary
This PR bumps the integration and project version to `1.4.3` in preparation for release.

# Key Changes
- Updated version tag to `1.4.3` in `custom_components/hyxi_cloud/manifest.json`.
- Updated version tag to `1.4.3` in `pyproject.toml`.

# Why this is needed
Prepares the repository metadata for the `v1.4.3` release tag.