### PR TITLE
feat: add battery SOC protection with configurable min/max thresholds

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -22,8 +22,12 @@ from .const import (
     MANUFACTURER,
     PLATFORMS,
     VERSION,
+    detect_phase_type,
+    get_raw_device_code,
+    normalize_device_type,
 )
 from .coordinator import HyxiDataUpdateCoordinator
+from .protection import HyxiBatteryProtectionController
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,6 +127,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
     _remove_legacy_select_entities(hass, coordinator.data)
+    await _async_setup_battery_protection(hass, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -133,6 +138,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    coordinator = hass.data[DOMAIN].get(entry.entry_id)
+    if coordinator is not None:
+        for controller in coordinator.protection_controllers.values():
+            await controller.async_stop()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
@@ -157,3 +166,21 @@ def _remove_legacy_select_entities(hass: HomeAssistant, devices: dict) -> None:
             if entity_id is not None:
                 _LOGGER.debug("Removing legacy HYXI select entity %s", entity_id)
                 registry.async_remove(entity_id)
+
+
+async def _async_setup_battery_protection(
+    hass: HomeAssistant,
+    coordinator: HyxiDataUpdateCoordinator,
+) -> None:
+    """Start battery protection on supported battery control devices."""
+    for sn, dev_data in coordinator.data.items():
+        device_type = normalize_device_type(get_raw_device_code(dev_data))
+        if device_type not in ("hybrid_inverter", "all_in_one"):
+            continue
+        phase = detect_phase_type(dev_data)
+        if phase not in ("three_phase", "single_phase"):
+            continue
+
+        controller = HyxiBatteryProtectionController(hass, coordinator, sn)
+        coordinator.protection_controllers[sn] = controller
+        await controller.async_start()

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -12,6 +12,7 @@ import logging
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -236,10 +237,12 @@ class HyxiModeButton(CoordinatorEntity, ButtonEntity):
             if self._mode == "idle":
                 await client.set_mode_idle(self._sn)
             elif self._mode == "charge":
+                _block_manual_charge_if_needed(self.coordinator, self._sn)
                 watts = _get_power_value(self.hass, self._sn, "charge")
                 _LOGGER.debug("Setting %s to CHARGE at %dW", mask_sn(self._sn), watts)
                 await client.set_mode_charge(self._sn, watts)
             elif self._mode == "discharge":
+                _block_manual_discharge_if_needed(self.coordinator, self._sn)
                 watts = _get_power_value(self.hass, self._sn, "discharge")
                 _LOGGER.debug(
                     "Setting %s to DISCHARGE at %dW", mask_sn(self._sn), watts
@@ -247,6 +250,7 @@ class HyxiModeButton(CoordinatorEntity, ButtonEntity):
                 await client.set_mode_discharge(self._sn, watts)
             elif self._mode == "self_consume":
                 await client.set_mode_self_consume(self._sn)
+            _note_manual_mode(self.coordinator, self._sn, self._mode)
             _LOGGER.info("Mode '%s' command sent to %s", self._mode, mask_sn(self._sn))
             await self.coordinator.async_request_refresh()
         except HyxiApiClient.ControlError as err:
@@ -288,7 +292,11 @@ class HyxiPeakShavingButton(CoordinatorEntity, ButtonEntity):
         """Send the peak shaving command to the inverter."""
         client = self.coordinator.client
         try:
+            _block_manual_peak_shaving_if_needed(
+                self.coordinator, self._sn, self._option
+            )
             await client.set_peak_shaving(self._sn, self._option)
+            _note_manual_mode(self.coordinator, self._sn, self._option)
             _LOGGER.info(
                 "Peak shaving '%s' command sent to %s", self._option, mask_sn(self._sn)
             )
@@ -335,3 +343,50 @@ def _get_power_value(hass: HomeAssistant, sn: str, direction: str) -> int:
         "Power number entity %s not available, using 100W default", entity_id
     )
     return 100
+
+
+def _note_manual_mode(coordinator, sn: str, mode: str) -> None:
+    """Track the last user-sent inverter mode for battery protection telemetry."""
+    if controller := _get_protection_controller(coordinator, sn):
+        controller.note_manual_mode(mode)
+
+
+def _block_manual_discharge_if_needed(coordinator, sn: str) -> None:
+    """Reject manual discharge when SOC protection says discharge is unsafe."""
+    if (
+        controller := _get_protection_controller(coordinator, sn)
+    ) is not None and controller.should_block_manual_discharge():
+        raise HomeAssistantError(
+            "Discharge blocked because battery SOC is at or below SOC Minimum"
+        )
+
+
+def _block_manual_charge_if_needed(coordinator, sn: str) -> None:
+    """Reject manual charge when SOC protection says charging is unsafe."""
+    if (
+        controller := _get_protection_controller(coordinator, sn)
+    ) is not None and controller.should_block_manual_charge():
+        raise HomeAssistantError(
+            "Charge blocked because battery SOC is at or above SOC Maximum"
+        )
+
+
+def _block_manual_peak_shaving_if_needed(coordinator, sn: str, option: str) -> None:
+    """Reject unsafe peak-shaving actions when SOC protection is active."""
+    controller = _get_protection_controller(coordinator, sn)
+    if controller is None:
+        return
+
+    if option == "discharge" and controller.should_block_manual_discharge():
+        raise HomeAssistantError(
+            "Peak shaving discharge blocked because battery SOC is at or below SOC Minimum"
+        )
+    if option == "charge" and controller.should_block_manual_charge():
+        raise HomeAssistantError(
+            "Peak shaving charge blocked because battery SOC is at or above SOC Maximum"
+        )
+
+
+def _get_protection_controller(coordinator, sn: str):
+    """Return the battery protection controller for a device."""
+    return getattr(coordinator, "protection_controllers", {}).get(sn)

--- a/custom_components/hyxi_cloud/coordinator.py
+++ b/custom_components/hyxi_cloud/coordinator.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
@@ -56,6 +56,7 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.client = client
         self.entry = entry
+        self.protection_controllers: dict[str, Any] = {}
 
         # 🚀 Store metadata on the object, not in the data dictionary!
         self.hyxi_metadata: HyxiMetadata = {

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -6,6 +6,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -26,6 +27,41 @@ _MAX_POWER_KEYS = {
     "charge": "maxChargePower",
     "discharge": "maxDischargePower",
 }
+
+PROTECTION_NUMBER_DEFS: list[dict[str, str | int]] = [
+    {
+        "key": "soc_min",
+        "unit": "%",
+        "min": 5,
+        "max": 50,
+        "default": 20,
+        "icon": "mdi:battery-20",
+    },
+    {
+        "key": "soc_max",
+        "unit": "%",
+        "min": 50,
+        "max": 100,
+        "default": 90,
+        "icon": "mdi:battery-90",
+    },
+    {
+        "key": "soc_min_hysteresis_pct",
+        "unit": "%",
+        "min": 0,
+        "max": 10,
+        "default": 2,
+        "icon": "mdi:battery-sync",
+    },
+    {
+        "key": "soc_max_hysteresis_pct",
+        "unit": "%",
+        "min": 0,
+        "max": 10,
+        "default": 2,
+        "icon": "mdi:battery-sync-outline",
+    },
+]
 
 
 async def async_setup_entry(
@@ -51,6 +87,13 @@ async def async_setup_entry(
             if phase == "three_phase":
                 entities.append(HyxiPowerNumber(coordinator, sn, dev_data, "charge"))
                 entities.append(HyxiPowerNumber(coordinator, sn, dev_data, "discharge"))
+
+            # SOC protection numbers for both three-phase and single-phase
+            if phase in ("three_phase", "single_phase"):
+                for definition in PROTECTION_NUMBER_DEFS:
+                    entities.append(
+                        HyxiProtectionNumber(coordinator, sn, dev_data, definition)
+                    )
         elif device_type == "micro_inverter":
             # Microinverter power limit (controlId 3012)
             entities.append(HyxiMicroPowerLimit(coordinator, sn, dev_data))
@@ -178,3 +221,55 @@ def _safe_int(val, default: int) -> int:
         return result if result > 0 else default
     except ValueError, TypeError:
         return default
+
+
+class HyxiProtectionNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
+    """Locally stored number for battery protection thresholds."""
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.BOX
+    _attr_native_step = 1
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator,
+        sn: str,
+        dev_data: dict,
+        definition: dict[str, str | int],
+    ) -> None:
+        """Initialize the protection number."""
+        super().__init__(coordinator)
+        key = str(definition["key"])
+        self._attr_unique_id = f"hyxi_{sn}_{key}"
+        self._attr_translation_key = key
+        self._attr_native_unit_of_measurement = str(definition["unit"])
+        self._attr_native_min_value = int(definition["min"])
+        self._attr_native_max_value = int(definition["max"])
+        self._attr_native_value = int(definition["default"])
+        self._attr_icon = str(definition["icon"])
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, sn)},
+            "name": dev_data.get("device_name") or f"Device {sn}",
+            "manufacturer": MANUFACTURER,
+            "model": dev_data.get("model"),
+            "serial_number": sn,
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last configured value."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            try:
+                self._attr_native_value = int(float(last_state.state))
+            except ValueError, TypeError:
+                _LOGGER.debug(
+                    "Could not restore protection number %s from state %s",
+                    self.unique_id,
+                    last_state.state,
+                )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the protection threshold value."""
+        self._attr_native_value = int(value)
+        self.async_write_ha_state()

--- a/custom_components/hyxi_cloud/protection.py
+++ b/custom_components/hyxi_cloud/protection.py
@@ -1,0 +1,287 @@
+"""Minimal battery protection for HYXI inverter mode controls."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, detect_phase_type
+
+if TYPE_CHECKING:
+    from .coordinator import HyxiDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SOC_MIN = 20
+DEFAULT_SOC_MAX = 90
+DEFAULT_SOC_MIN_HYSTERESIS = 2
+DEFAULT_SOC_MAX_HYSTERESIS = 2
+MODE_SWITCH_COOLDOWN = 60
+
+
+class HyxiBatteryProtectionController:
+    """Protect battery SOC limits for supported HYXI manual controls."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: HyxiDataUpdateCoordinator,
+        sn: str,
+    ) -> None:
+        """Initialize the battery protection controller."""
+        self._hass = hass
+        self._coordinator = coordinator
+        self._sn = sn
+        self._last_sent_mode: str | None = None
+        self._low_soc_hold = False
+        self._high_soc_hold = False
+        self._last_mode_switch = 0.0
+        self._unsub_listener: CALLBACK_TYPE | None = None
+
+    @property
+    def last_sent_mode(self) -> str | None:
+        """Return the last tracked mode command."""
+        return self._last_sent_mode
+
+    async def async_start(self) -> None:
+        """Start listening for coordinator updates."""
+        if self._unsub_listener is not None:
+            return
+        self._unsub_listener = self._coordinator.async_add_listener(
+            self._handle_coordinator_update
+        )
+        await self.async_evaluate()
+
+    async def async_stop(self) -> None:
+        """Stop listening for coordinator updates."""
+        if self._unsub_listener is not None:
+            self._unsub_listener()
+            self._unsub_listener = None
+
+    def note_manual_mode(self, mode: str) -> None:
+        """Track a user-triggered mode command."""
+        self._last_sent_mode = mode
+
+    async def async_restore_last_sent_mode(self, mode: str) -> None:
+        """Restore the last tracked mode and replay it after restart."""
+        if mode not in {
+            "idle",
+            "charge",
+            "discharge",
+            "self_consume",
+            "close",
+            "stop",
+            "hold",
+        }:
+            return
+
+        await self._send_control(mode)
+
+        self._last_sent_mode = mode
+        self._last_mode_switch = time.monotonic()
+        await self._coordinator.async_request_refresh()
+
+    def should_block_manual_discharge(self) -> bool:
+        """Return True when manual discharge should be blocked by SOC protection."""
+        soc = self._get_soc()
+        if soc is None:
+            return False
+        soc_min = self._get_param("soc_min", DEFAULT_SOC_MIN)
+        return soc <= soc_min
+
+    def should_block_manual_charge(self) -> bool:
+        """Return True when manual charge should be blocked by SOC protection."""
+        soc = self._get_soc()
+        if soc is None:
+            return False
+
+        soc_max = self._get_param("soc_max", DEFAULT_SOC_MAX)
+        soc_max_resume = max(
+            0,
+            soc_max
+            - self._get_param(
+                "soc_max_hysteresis_pct",
+                DEFAULT_SOC_MAX_HYSTERESIS,
+            ),
+        )
+
+        if soc >= soc_max:
+            return True
+        return self._high_soc_hold and soc > soc_max_resume
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Evaluate protection rules after new coordinator data arrives."""
+        self._hass.async_create_task(self.async_evaluate())
+
+    async def async_evaluate(self) -> None:
+        """Evaluate the current SOC and enforce protection limits."""
+        dev_data = (self._coordinator.data or {}).get(self._sn)
+        if not dev_data:
+            return
+
+        metrics = dev_data.get("metrics") or {}
+        soc = self._metric_float(metrics.get("batSoc"))
+        if soc is None:
+            return
+
+        soc_min = self._get_param("soc_min", DEFAULT_SOC_MIN)
+        soc_max = self._get_param("soc_max", DEFAULT_SOC_MAX)
+        phase = self._phase_type()
+        soc_min_resume = min(
+            soc_max,
+            soc_min
+            + self._get_param(
+                "soc_min_hysteresis_pct",
+                DEFAULT_SOC_MIN_HYSTERESIS,
+            ),
+        )
+        soc_max_resume = max(
+            soc_min,
+            soc_max
+            - self._get_param(
+                "soc_max_hysteresis_pct",
+                DEFAULT_SOC_MAX_HYSTERESIS,
+            ),
+        )
+
+        if soc <= soc_min:
+            self._low_soc_hold = True
+            if self._last_sent_mode != "charge":
+                await self._ensure_mode("hold" if phase == "single_phase" else "idle")
+            return
+
+        if self._low_soc_hold:
+            if soc < soc_min_resume:
+                if self._last_sent_mode != "charge":
+                    await self._ensure_mode(
+                        "hold" if phase == "single_phase" else "idle"
+                    )
+                return
+            self._low_soc_hold = False
+
+        if soc >= soc_max:
+            self._high_soc_hold = True
+            if phase == "single_phase":
+                if self._last_sent_mode not in ("discharge", "hold"):
+                    await self._ensure_mode("hold")
+            elif self._last_sent_mode not in ("discharge", "idle", "self_consume"):
+                await self._ensure_mode("idle")
+            return
+
+        if self._high_soc_hold:
+            if soc > soc_max_resume:
+                if phase == "single_phase":
+                    if self._last_sent_mode not in ("discharge", "hold"):
+                        await self._ensure_mode("hold")
+                elif self._last_sent_mode not in (
+                    "discharge",
+                    "idle",
+                    "self_consume",
+                ):
+                    await self._ensure_mode("idle")
+                return
+            self._high_soc_hold = False
+
+    async def _ensure_mode(self, mode: str) -> None:
+        """Send a mode command if cooldown allows it and mode changed."""
+        if self._last_sent_mode == mode:
+            return
+        if (time.monotonic() - self._last_mode_switch) < MODE_SWITCH_COOLDOWN:
+            return
+
+        await self._send_control(mode)
+
+        self._last_sent_mode = mode
+        self._last_mode_switch = time.monotonic()
+        await self._coordinator.async_request_refresh()
+
+    async def _send_control(self, mode: str) -> None:
+        """Send the requested control using the correct phase-specific API."""
+        client = self._coordinator.client
+        phase = self._phase_type()
+
+        if phase == "three_phase":
+            if mode == "idle":
+                await client.set_mode_idle(self._sn)
+            elif mode == "charge":
+                await client.set_mode_charge(self._sn, self._get_power_value("charge"))
+            elif mode == "discharge":
+                await client.set_mode_discharge(
+                    self._sn, self._get_power_value("discharge")
+                )
+            elif mode == "self_consume":
+                await client.set_mode_self_consume(self._sn)
+            else:
+                raise ValueError(f"Unsupported three-phase protection mode: {mode}")
+            return
+
+        if phase == "single_phase":
+            if mode not in {"close", "charge", "discharge", "stop", "hold"}:
+                raise ValueError(f"Unsupported single-phase protection mode: {mode}")
+            await client.set_peak_shaving(self._sn, mode)
+            return
+
+        raise ValueError(f"Unsupported phase type for protection: {phase}")
+
+    def _get_param(self, key: str, default: int) -> int:
+        """Read a protection number value from the entity registry."""
+        unique_id = f"hyxi_{self._sn}_{key}"
+        registry = er.async_get(self._hass)
+        entity_id = registry.async_get_entity_id("number", DOMAIN, unique_id)
+        if entity_id is None:
+            return default
+
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable", ""):
+            return default
+
+        try:
+            return int(float(state.state))
+        except ValueError, TypeError:
+            return default
+
+    def _get_power_value(self, direction: str) -> int:
+        """Read the stored charge or discharge power value."""
+        unique_id = f"hyxi_{self._sn}_{direction}_power"
+        registry = er.async_get(self._hass)
+        entity_id = registry.async_get_entity_id("number", DOMAIN, unique_id)
+        if entity_id is None:
+            return 100
+
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable", ""):
+            return 100
+
+        try:
+            watts = int(float(state.state))
+            return max(watts, 1)
+        except ValueError, TypeError:
+            return 100
+
+    def _get_soc(self) -> float | None:
+        """Read the current battery SOC."""
+        dev_data = (self._coordinator.data or {}).get(self._sn)
+        if not dev_data:
+            return None
+        metrics = dev_data.get("metrics") or {}
+        return self._metric_float(metrics.get("batSoc"))
+
+    def _phase_type(self) -> str:
+        """Return the detected phase type for this device."""
+        dev_data = (self._coordinator.data or {}).get(self._sn) or {}
+        return detect_phase_type(dev_data)
+
+    @staticmethod
+    def _metric_float(value) -> float | None:
+        """Parse a coordinator metric as float."""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except ValueError, TypeError:
+            return None

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     DOMAIN,
     MANUFACTURER,
+    detect_phase_type,
     get_raw_device_code,
     get_software_version,
     is_null_value,
@@ -896,6 +897,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # 2. Integration Health
     entities.append(HyxiLastUpdateSensor(coordinator, entry))
 
+    # 3. Battery protection telemetry
+    for sn, dev_data in coordinator.data.items():
+        device_type = normalize_device_type(get_raw_device_code(dev_data))
+        if device_type not in ("hybrid_inverter", "all_in_one"):
+            continue
+        phase = detect_phase_type(dev_data)
+        if phase not in ("three_phase", "single_phase"):
+            continue
+        entities.append(HyxiLastSentModeSensor(coordinator, sn))
+
     # FINAL REGISTRATION
     if entities:
         async_add_entities(entities)
@@ -1239,3 +1250,54 @@ class HyxiLastUpdateSensor(CoordinatorEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         self._update_native_value()
         super()._handle_coordinator_update()
+
+
+class HyxiLastSentModeSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
+    """Sensor exposing the last tracked mode command for a protected inverter."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "last_sent_mode"
+
+    def __init__(self, coordinator, sn: str) -> None:
+        """Initialize the last sent mode sensor."""
+        super().__init__(coordinator)
+        self._sn = sn
+        self._attr_unique_id = f"hyxi_{sn}_last_sent_mode"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last tracked mode and replay it after restart."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is None:
+            return
+
+        mode = last_state.state
+        if mode in ("unknown", "unavailable", ""):
+            return
+
+        if controller := _get_protection_controller(self.coordinator, self._sn):
+            await controller.async_restore_last_sent_mode(mode)
+
+    @property
+    def device_info(self):
+        """Return the linked inverter device info."""
+        dev_data = self.coordinator.data.get(self._sn) or {}
+        return {
+            "identifiers": {(DOMAIN, self._sn)},
+            "name": dev_data.get("device_name") or f"Device {self._sn}",
+            "manufacturer": MANUFACTURER,
+            "model": dev_data.get("model"),
+            "serial_number": self._sn,
+        }
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the last tracked mode command."""
+        controller = _get_protection_controller(self.coordinator, self._sn)
+        if controller is None:
+            return None
+        return controller.last_sent_mode
+
+
+def _get_protection_controller(coordinator, sn: str):
+    """Return the battery protection controller for a device."""
+    return getattr(coordinator, "protection_controllers", {}).get(sn)

--- a/custom_components/hyxi_cloud/strings.json
+++ b/custom_components/hyxi_cloud/strings.json
@@ -412,6 +412,9 @@
       },
       "ratedfrequency": {
         "name": "Rated Frequency"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -423,6 +426,18 @@
       },
       "micro_power_limit": {
         "name": "Power Limit"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/af.json
+++ b/custom_components/hyxi_cloud/translations/af.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nominale frekwensie"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Kragbeperking"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/cs.json
+++ b/custom_components/hyxi_cloud/translations/cs.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Jmenovitá frekvence"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Limit výkonu"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/da.json
+++ b/custom_components/hyxi_cloud/translations/da.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nominel frekvens"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Effektgrænse"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/de.json
+++ b/custom_components/hyxi_cloud/translations/de.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nennfrequenz"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Leistungsbegrenzung"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/en.json
+++ b/custom_components/hyxi_cloud/translations/en.json
@@ -411,6 +411,9 @@
       },
       "ratedfrequency": {
         "name": "Rated Frequency"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -422,6 +425,18 @@
       },
       "micro_power_limit": {
         "name": "Power Limit"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/es.json
+++ b/custom_components/hyxi_cloud/translations/es.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Frecuencia nominal"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Límite de potencia"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/fi.json
+++ b/custom_components/hyxi_cloud/translations/fi.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nimellistaajuus"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Tehoraja"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/fr.json
+++ b/custom_components/hyxi_cloud/translations/fr.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Fréquence nominale"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Limite de puissance"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/hu.json
+++ b/custom_components/hyxi_cloud/translations/hu.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Névleges frekvencia"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Teljesítménykorlát"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/it.json
+++ b/custom_components/hyxi_cloud/translations/it.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Frequenza nominale"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Limite di potenza"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/ja.json
+++ b/custom_components/hyxi_cloud/translations/ja.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "定格周波数"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "出力制限"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/nb.json
+++ b/custom_components/hyxi_cloud/translations/nb.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nominell frekvens"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Effektgrense"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/nl.json
+++ b/custom_components/hyxi_cloud/translations/nl.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nominale frequentie"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Vermogenslimiet"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/pl.json
+++ b/custom_components/hyxi_cloud/translations/pl.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Częstotliwość znamionowa"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Limit mocy"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/pt-BR.json
+++ b/custom_components/hyxi_cloud/translations/pt-BR.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Frequência nominal"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Limite de potência"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/pt.json
+++ b/custom_components/hyxi_cloud/translations/pt.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Frequência nominal"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Limite de potência"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/ru.json
+++ b/custom_components/hyxi_cloud/translations/ru.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Номинальная частота"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Ограничение мощности"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/sv.json
+++ b/custom_components/hyxi_cloud/translations/sv.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nominell frekvens"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Effektgräns"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/tr.json
+++ b/custom_components/hyxi_cloud/translations/tr.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "Nominal Frekans"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "Güç Sınırı"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/custom_components/hyxi_cloud/translations/zh-Hans.json
+++ b/custom_components/hyxi_cloud/translations/zh-Hans.json
@@ -410,6 +410,9 @@
       },
       "ratedfrequency": {
         "name": "额定频率"
+      },
+      "last_sent_mode": {
+        "name": "Last Sent Mode"
       }
     },
     "number": {
@@ -421,6 +424,18 @@
       },
       "micro_power_limit": {
         "name": "功率限制"
+      },
+      "soc_min": {
+        "name": "SOC Minimum"
+      },
+      "soc_max": {
+        "name": "SOC Maximum"
+      },
+      "soc_min_hysteresis_pct": {
+        "name": "SOC Min Hysteresis"
+      },
+      "soc_max_hysteresis_pct": {
+        "name": "SOC Max Hysteresis"
       }
     },
     "switch": {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -80,6 +80,7 @@ def mock_coordinator_fixture():
     coord.client.set_peak_shaving = AsyncMock()
     coord.client.alter_alarm = AsyncMock()
     coord.async_request_refresh = AsyncMock()
+    coord.protection_controllers = {}
     return coord
 
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -56,6 +56,7 @@ ensure_mock("homeassistant.components.binary_sensor")
 ensure_mock("homeassistant.config_entries")
 ensure_mock("homeassistant.core")
 ensure_mock("homeassistant.helpers")
+ensure_mock("homeassistant.helpers.entity")
 ensure_mock("homeassistant.helpers.aiohttp_client")
 ensure_mock("homeassistant.helpers.device_registry")
 ensure_mock("homeassistant.helpers.entity_platform")
@@ -162,8 +163,12 @@ async def test_async_setup_entry():
     async_add_entities.assert_called_once()
     entities = async_add_entities.call_args[0][0]
 
-    # Expect 2 for SN1 (charge/discharge) and 1 for SN3 (micro power limit), none for SN2
-    assert len(entities) == 3
+    # Expect:
+    #   SN1 (three-phase): 2 power + 4 protection = 6
+    #   SN2 (single-phase): 4 protection = 4
+    #   SN3 (micro): 1 micro power limit
+    #   Total = 11
+    assert len(entities) == 11
     assert any(
         isinstance(e, number_mod.HyxiPowerNumber)
         and e._direction == "charge"
@@ -180,6 +185,11 @@ async def test_async_setup_entry():
         isinstance(e, number_mod.HyxiMicroPowerLimit) and e._sn == "SN3"
         for e in entities
     )
+    # Verify protection numbers exist for both phases
+    protection_entities = [
+        e for e in entities if isinstance(e, number_mod.HyxiProtectionNumber)
+    ]
+    assert len(protection_entities) == 8  # 4 per phase x 2 devices
 
 
 def test_hyxi_power_number_init():

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -1,0 +1,256 @@
+"""Tests for minimal battery protection logic."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.hyxi_cloud.protection import HyxiBatteryProtectionController
+
+
+class FakeCoordinator:
+    """Minimal coordinator stub for protection tests."""
+
+    def __init__(self, soc: float, model: str = "H5K-HT") -> None:
+        self.data = {
+            "SN123": {
+                "model": model,
+                "metrics": {"batSoc": soc},
+            }
+        }
+        self.client = SimpleNamespace(
+            set_mode_idle=AsyncMock(),
+            set_mode_charge=AsyncMock(),
+            set_mode_discharge=AsyncMock(),
+            set_mode_self_consume=AsyncMock(),
+            set_peak_shaving=AsyncMock(),
+        )
+        self.async_request_refresh = AsyncMock()
+
+    def async_add_listener(self, listener):
+        """Return a no-op unsubscribe callback."""
+        return lambda: None
+
+
+def _build_controller(
+    soc: float, model: str = "H5K-HT"
+) -> HyxiBatteryProtectionController:
+    """Create a controller with parameter lookups stubbed."""
+    hass = SimpleNamespace(async_create_task=lambda coro: None)
+    controller = HyxiBatteryProtectionController(
+        hass, FakeCoordinator(soc, model), "SN123"
+    )
+
+    def get_param(key, default):
+        return {
+            "soc_min": 20,
+            "soc_max": 90,
+            "soc_min_hysteresis_pct": 2,
+            "soc_max_hysteresis_pct": 2,
+        }.get(key, default)
+
+    controller._get_param = get_param  # type: ignore[method-assign]
+    controller._ensure_mode = AsyncMock()  # type: ignore[method-assign]
+    return controller
+
+
+# --- Low SOC Protection ---
+
+
+@pytest.mark.asyncio
+async def test_low_soc_triggers_idle_hold():
+    """SOC at or below the minimum should force idle."""
+    controller = _build_controller(20)
+
+    await controller.async_evaluate()
+
+    assert controller._low_soc_hold is True
+    controller._ensure_mode.assert_awaited_once_with("idle")
+
+
+@pytest.mark.asyncio
+async def test_low_soc_allows_manual_charge_recovery():
+    """Low-SOC protection should not block a user charging the battery back up."""
+    controller = _build_controller(20)
+    controller.note_manual_mode("charge")
+
+    await controller.async_evaluate()
+
+    assert controller._low_soc_hold is True
+    controller._ensure_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_low_soc_hysteresis_keeps_idle_until_resume():
+    """Low-SOC hold should remain active until the resume threshold is crossed."""
+    controller = _build_controller(21)
+    controller._low_soc_hold = True
+
+    await controller.async_evaluate()
+
+    assert controller._low_soc_hold is True
+    controller._ensure_mode.assert_awaited_once_with("idle")
+
+
+@pytest.mark.asyncio
+async def test_low_soc_hysteresis_clears_above_resume():
+    """Crossing soc_min + hysteresis should release the low-SOC hold."""
+    controller = _build_controller(23)
+    controller._low_soc_hold = True
+
+    await controller.async_evaluate()
+
+    assert controller._low_soc_hold is False
+    controller._ensure_mode.assert_not_awaited()
+
+
+# --- High SOC Protection ---
+
+
+@pytest.mark.asyncio
+async def test_soc_max_stops_tracked_charge_mode():
+    """A tracked charge mode should be forced to idle when SOC reaches the max."""
+    controller = _build_controller(90)
+    controller.note_manual_mode("charge")
+
+    await controller.async_evaluate()
+
+    assert controller._high_soc_hold is True
+    controller._ensure_mode.assert_awaited_once_with("idle")
+
+
+@pytest.mark.asyncio
+async def test_soc_max_ignores_unknown_mode():
+    """No extra command is needed when the inverter is already idle at soc_max."""
+    controller = _build_controller(90)
+    controller.note_manual_mode("idle")
+
+    await controller.async_evaluate()
+
+    controller._ensure_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_high_soc_hysteresis_keeps_charge_paths_blocked():
+    """Three-phase upper hold should stay active without blocking self-consume."""
+    controller = _build_controller(89)
+    controller._high_soc_hold = True
+    controller.note_manual_mode("self_consume")
+
+    await controller.async_evaluate()
+
+    assert controller._high_soc_hold is True
+    controller._ensure_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_high_soc_hysteresis_clears_below_resume():
+    """Upper hold should clear once SOC drops to the release threshold."""
+    controller = _build_controller(88)
+    controller._high_soc_hold = True
+    controller.note_manual_mode("idle")
+
+    await controller.async_evaluate()
+
+    assert controller._high_soc_hold is False
+    controller._ensure_mode.assert_not_awaited()
+
+
+# --- Mode Restore ---
+
+
+@pytest.mark.asyncio
+async def test_restore_replays_last_idle_mode():
+    """Restoring an idle state should resend the idle command."""
+    controller = _build_controller(50)
+
+    await controller.async_restore_last_sent_mode("idle")
+
+    controller._coordinator.client.set_mode_idle.assert_awaited_once_with("SN123")
+    assert controller.last_sent_mode == "idle"
+
+
+@pytest.mark.asyncio
+async def test_restore_replays_last_charge_mode_with_saved_power():
+    """Restoring charge should replay the charge command with stored power."""
+    controller = _build_controller(50)
+    controller._get_power_value = lambda direction: 750  # type: ignore[method-assign]
+
+    await controller.async_restore_last_sent_mode("charge")
+
+    controller._coordinator.client.set_mode_charge.assert_awaited_once_with(
+        "SN123", 750
+    )
+    assert controller.last_sent_mode == "charge"
+
+
+# --- Manual Blocking ---
+
+
+def test_manual_discharge_blocked_at_soc_min():
+    """Manual discharge should be blocked at or below the configured floor."""
+    controller = _build_controller(20)
+
+    assert controller.should_block_manual_discharge() is True
+
+
+def test_manual_discharge_allowed_above_soc_min():
+    """Manual discharge should remain allowed above the configured floor."""
+    controller = _build_controller(21)
+
+    assert controller.should_block_manual_discharge() is False
+
+
+def test_manual_charge_blocked_at_soc_max():
+    """Manual charge should be blocked once SOC reaches the upper limit."""
+    controller = _build_controller(90)
+
+    assert controller.should_block_manual_charge() is True
+
+
+def test_manual_charge_allowed_below_upper_release_threshold():
+    """Manual charge should be allowed again after the upper hysteresis releases."""
+    controller = _build_controller(88)
+    controller._high_soc_hold = True
+
+    assert controller.should_block_manual_charge() is False
+
+
+# --- Single-Phase Behavior ---
+
+
+@pytest.mark.asyncio
+async def test_single_phase_low_soc_forces_hold():
+    """Single-phase low-SOC protection should force hold rather than idle."""
+    controller = _build_controller(20, "H5K-HS")
+
+    await controller.async_evaluate()
+
+    assert controller._low_soc_hold is True
+    controller._ensure_mode.assert_awaited_once_with("hold")
+
+
+@pytest.mark.asyncio
+async def test_single_phase_high_soc_keeps_hold_allowed():
+    """Single-phase upper hold should allow hold without forcing another action."""
+    controller = _build_controller(89, "H5K-HS")
+    controller._high_soc_hold = True
+    controller.note_manual_mode("hold")
+
+    await controller.async_evaluate()
+
+    assert controller._high_soc_hold is True
+    controller._ensure_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_phase_restore_replays_hold_action():
+    """Single-phase restore should replay the last peak-shaving action."""
+    controller = _build_controller(50, "H5K-HS")
+
+    await controller.async_restore_last_sent_mode("hold")
+
+    controller._coordinator.client.set_peak_shaving.assert_awaited_once_with(
+        "SN123", "hold"
+    )
+    assert controller.last_sent_mode == "hold"


### PR DESCRIPTION
Sorry for the long wait for this.


Automated mode switching protects battery from over-discharge (forces idle/hold) and over-charge (stops charging) based on user-configurable SOC limits with hysteresis. Supports both three-phase (operating mode) and single-phase (peak shaving) inverters. Adds protection number entities (soc_min, soc_max, hysteresis), last-sent-mode sensor with restore-on-restart, and manual command blocking when SOC limits active.

# 🛰️ HYXi Cloud  PR

## 📝 Description
## 💡 Rationale
<details>
<summary><b>🛠️ Change Manifest (Technical)</b></summary>

- [x] Automated tests (Pytest/Hypothesis) must pass for merge.
- [x] Linting requirements (Ruff) must be met.
- [ ] Logic impacts `custom_components`?
- [ ] Logic impacts `api_client`?
</details>

---

## 📸 Validation & Logs
## 🔗 Traceability
- **Relates to:** #
- **Closes:** #
