### PR TITLE
chore: bump hyxi-cloud-api requirement to 1.2.6

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.5"
+    "hyxi-cloud-api>=1.2.6"
   ],
   "version": "1.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.2.5"
+    "hyxi-cloud-api>=1.2.6"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.5
+hyxi-cloud-api>=1.2.6
 
 # Development/Linting tools
 ruff>=0.15.14

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.9
-hyxi-cloud-api>=1.2.5
+hyxi-cloud-api>=1.2.6
 pytest-homeassistant-custom-component>=0.13.333


### PR DESCRIPTION
## Summary
This Pull Request updates the integration dependency requirements for `hyxi-cloud-api` to `>=1.2.6`.

## Key Changes
- Bump dependency requirement to `hyxi-cloud-api>=1.2.6` in `manifest.json`, `pyproject.toml`, `requirements.txt`, and `requirements_test.txt`.

## Why this is needed
Aligns the Home Assistant integration with the released VPP control lockouts and node-switching cleanup in the `hyxi-cloud-api` 1.2.6 library.