### PR TITLE
feat: add Energy Manager with automated battery control

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,226 @@ The HYXI API defines controls by **phase type** (Single Phase / Three-Phase). Th
 > [!IMPORTANT]
 > If the phase type cannot be determined from either the model name or runtime metrics, **no control entities are created**. This is a safety measure to prevent sending unsupported commands to your inverter. If you believe your device should have controls, please open a [GitHub Issue](https://github.com/Veldkornet/ha-hyxi-cloud/issues) with your device model and we will add support.
 
+#### Energy Manager Standalone (Beta)
+
+The Energy Manager Standalone is an automated battery control engine that runs a 15-second decision loop inside Home Assistant. It reads your P1 smart meter, solar production, battery SOC, and optional solar forecast to automatically manage your inverter's operating mode (charge, discharge, self-consume, idle).
+
+> [!NOTE]
+> This is the **Standalone** energy manager — it makes all decisions locally based on real-time sensor data and configurable rules. A future **Day Ahead** energy manager (optimizing against dynamic energy prices) is planned for a separate release.
+
+**Important:** The Energy Manager builds on top of the existing Battery Protection — it does **not** replace it. SOC minimum/maximum limits are read from the existing protection number entities and are always respected.
+
+##### Prerequisites
+
+- **Enable Device Control & Protection** must be turned on first (Options → Configure)
+- A **P1 smart meter** entity (power sensor) configured in Home Assistant
+
+##### Enabling
+
+1. Go to **Settings > Devices & Services** > **HYXI Cloud** > **Configure**.
+2. Enable **Device Control & Protection** and save.
+3. Re-open **Configure** — the **Enable Energy Manager Standalone (Beta)** toggle is now visible.
+4. Enable it and configure:
+   - **P1 Smart Meter** — your grid power sensor (required, e.g. `sensor.p1_meter_power`)
+   - **Solar Forecast Remaining Today** — remaining solar energy for today in kWh (optional)
+   - **Solar Forecast Current Power** — current predicted solar power in W (optional)
+   - **Inverter to Control** — which inverter the engine manages
+   - **Override Battery Capacity** — check this to manually set battery capacity (see below)
+   - **Battery Capacity (Wh)** — manual override value (only used when override is checked)
+
+The Energy Manager is **disabled by default** even after enabling it in options. You must also turn on the **Energy Manager** switch entity. Each sub-feature (Night Mode, High Load Assist) must be individually enabled via its own switch entity.
+
+##### Solar Forecast Integration
+
+The engine can use solar forecast data to make smarter decisions about battery preservation and charge timing. Two optional forecast entities can be configured:
+
+- **Solar Forecast Remaining Today (kWh):** Used for night preservation decisions — the engine checks whether remaining solar can recharge the battery to the night target before sunset. Compatible with:
+  - [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar/) — use the `energy_production_today_remaining` sensor
+  - [Solcast](https://github.com/BJReplay/ha-solcast-solar) — use the `forecast_remaining_today` sensor
+  - Any sensor providing remaining solar energy for today in kWh
+
+- **Solar Forecast Current Power (W):** Currently reserved for future use. Compatible with:
+  - [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar/) — use the `power_production_now` sensor
+  - [Solcast](https://github.com/BJReplay/ha-solcast-solar) — use the `forecast_this_hour` sensor
+
+If no forecast entities are configured, the engine estimates solar availability from current production and time to sunset.
+
+##### Battery Capacity
+
+The engine needs to know your battery's total capacity (in Wh) for SOC calculations, night reserve estimation, and high-load cost analysis.
+
+**How it's determined (in priority order):**
+
+1. **Manual override** — If you check *Override Battery Capacity* in the energy manager options and set a value, that value is always used.
+2. **API auto-detection** — The `batCap` metric from your inverter (reported in kWh, converted to Wh). Most hybrid inverters report this automatically.
+3. **Fallback** — 2000 Wh if neither of the above is available.
+
+> [!TIP]
+> If your inverter reports `batCap` correctly (visible as the "Battery Capacity" sensor on your inverter device), you don't need to configure anything. The override is for situations where the API value is missing, incorrect, or you have modified your battery setup.
+
+##### How It Works — Decision Priorities
+
+Every 15 seconds the engine evaluates these priorities in order. The first matching priority wins:
+
+| Priority | Condition | Action | Details |
+| :--- | :--- | :--- | :--- |
+| **1. Emergency Low SOC** | SOC < SOC Minimum | Charge from solar or grid | If solar is producing, charges from solar. If no solar and *Grid Charge Allowed* is on, charges from grid at up to 2000W. Otherwise goes idle to prevent further drain. |
+| **2. Over-Max SOC** | SOC > SOC Maximum | Forced discharge | Discharges at the higher of current grid import or 1000W, capped at max discharge power. Prevents overcharging. |
+| **2b. Export Limiting** | Grid export > max limit | Charge or curtail PV | Single-phase only. Uses peak shaving control. See details below. |
+| **3. High Load Assist** | Home load > threshold | Battery assist or grid-only | Only active when the *High Load Battery Assist* switch is ON. See details below. |
+| **4. Night Mode** | Nighttime (sun below horizon) | Self-consume or idle | Only active when the *Night Mode* switch is ON. See details below. |
+| **5. Solar Optimization** | Solar producing + SOC < max | Smart charge from solar | Waits for sustained grid export before entering charge mode. Continuously tunes charge power to minimize grid import/export. |
+| **Default** | None of the above | Self-consume | Safe fallback. If currently charging or discharging, switches to self-consume. |
+
+##### Night Mode (Priority 4)
+
+**Requires:** *Night Mode* switch entity → ON (default: OFF)
+
+Night Mode manages battery usage during nighttime and preserves battery for overnight consumption:
+
+- **At night (sun below horizon, no solar):**
+  - If SOC is above SOC Minimum → **self-consume** (battery powers the house)
+  - If SOC is at or below SOC Minimum → **idle** (stop discharging, protect the reserve)
+
+- **During daytime — night preservation:**
+  - If SOC has dropped to or below the calculated *night SOC target* and the house is importing from grid and solar forecast cannot cover the gap → **idle** (preserve remaining battery for tonight)
+
+The **night SOC target** is automatically calculated based on:
+- `Average Night Consumption` (W) — configurable, also auto-updated hourly from real P1 data between 21:00–06:00
+- `Night Buffer %` — extra safety margin (default 5%)
+- Battery capacity (from options or API)
+- Hours until sunrise
+
+Formula: `night_target = soc_min + ((avg_consumption × hours_remaining × (1 + buffer%)) / capacity) × 100`
+
+**Example:** With 400W average consumption, 14.8 kWh battery, 5% buffer, 20% SOC minimum, 12 hours until sunrise:
+Night target ≈ 20% + 34% = **54%**. The engine will preserve battery above 54% during daytime if it calculates that solar won't be enough to recharge before sunset.
+
+##### High Load Assist (Priority 3)
+
+**Requires:** *High Load Battery Assist* switch entity → ON (default: OFF)
+
+High Load Assist detects when your home consumption exceeds a configurable threshold and decides whether the battery should help:
+
+- **Home load > High Load Threshold** and assist is enabled:
+  - Calculates the SOC cost of running battery assist for 30 minutes at 50% max discharge power
+  - If the battery can afford it (remaining SOC after assist would still exceed the night SOC target) → **self-consume** (battery helps power the high load)
+  - If the battery cannot afford it (would drain below night target) → **idle** (let the grid handle it, preserve battery for night)
+
+- **Home load below threshold:** No action, falls through to next priority.
+
+**Use case:** Running an oven, EV charger, or heat pump. The engine prevents the battery from draining itself to cover a temporary spike that would leave you with insufficient reserve for the night.
+
+##### Export Limiting (Priority 2b)
+
+**Requires:** *Export Limiting* switch entity → ON (default: OFF)
+
+**Single-phase devices only** — uses peak shaving control (controlId 1021) which is not available on three-phase inverters.
+
+Export Limiting caps how much power is fed back to the grid:
+
+- **Grid export > Max Grid Export** and battery has room (SOC < SOC Maximum):
+  - Charges battery to absorb excess (minimum 300W, capped at max charge power)
+  - Continuously adjusts charge power as export fluctuates
+
+- **Grid export > Max Grid Export** and battery is full:
+  - Sends peak shaving `stop` to curtail PV production entirely
+  - 30-second cooldown between stop/hold toggles prevents oscillation
+
+- **Grid export drops below limit:**
+  - Sends peak shaving `hold` to resume PV production
+  - Returns to self-consume
+
+**Use case:** Feed-in tariff limits, grid connection limits, or reducing grid export to maximize self-consumption.
+
+##### Solar Charge Logic (Priority 5)
+
+When solar is producing and the battery isn't full, the engine optimizes charging:
+
+1. **Entry gate:** Solar must exceed `Min Solar for Charge` (default: 1000W).
+2. **Export confirmation:** Grid export must exceed `Charge Entry Threshold` (default: 500W) for several consecutive readings before entering charge mode. This prevents charge/discharge oscillation on cloudy days.
+3. **Power tuning:** Once charging, the engine continuously adjusts charge power to keep P1 close to zero (not importing, not exporting).
+4. **Bottomout exit:** If charge power drops to minimum (100W) for 3 consecutive ticks due to insufficient solar, exits back to self-consume.
+5. **Sunset urgency:** Within 4 hours of sunset, if SOC is below the night target and solar forecast won't cover it, entry thresholds are relaxed to capture remaining solar.
+
+##### Grid Charge Allowed
+
+The *Grid Charge Allowed* switch (on the inverter device, not the Energy Manager device) controls whether the engine may charge the battery from the grid during emergencies. This is only used when SOC drops below minimum and there is no solar available. Default: OFF.
+
+##### Entity Reference
+
+All Energy Manager entities appear on a virtual **Energy Manager** device linked to your inverter.
+
+**Switches (all default OFF):**
+
+| Entity | Purpose |
+| :--- | :--- |
+| Energy Manager | Master on/off for the decision loop |
+| Night Mode | Enable night self-consume and battery preservation |
+| High Load Battery Assist | Enable battery assist during high home loads |
+| Export Limiting | Cap grid export and charge battery with excess (single-phase only) |
+| Grid Charge Allowed | Allow grid charging in low-SOC emergencies (on inverter device) |
+
+**Number parameters:**
+
+| Entity | Unit | Default | Range | Purpose |
+| :--- | :--- | :--- | :--- | :--- |
+| High Load Threshold | W | 6500 | 1000–20000 | Home load above this triggers high-load logic |
+| Max Charge Power | W | 5000 | 500–15000 | Maximum charge power sent to inverter |
+| Max Discharge Power | W | 5000 | 500–15000 | Maximum discharge power |
+| Min Solar for Charge | W | 1000 | 200–3000 | Solar must exceed this to consider charging |
+| Mode Switch Cooldown | s | 60 | 10–300 | Minimum seconds between mode changes |
+| Power Change Threshold | W | 100 | 10–500 | Minimum power change before resending command |
+| Power Adjust Cooldown | s | 30 | 5–120 | Minimum seconds between power adjustments |
+| Night Buffer | % | 5 | 0–20 | Extra safety margin for night SOC calculation |
+| Avg Night Consumption | W | 400 | 100–2000 | Baseline night power draw (auto-updated hourly) |
+| Charge Margin | W | 150 | 0–500 | Buffer between solar charge and grid balance point |
+| Charge Entry Threshold | W | 500 | 100–2000 | Grid export required before entering charge mode |
+| Charge Re-entry Delay | s | 300 | 30–600 | Cooldown before re-entering charge after exit |
+| Bottomout Cooldown | s | 300 | 60–900 | Extended cooldown after charge bottomout exit |
+| P1 Smoothing Period | s | 60 | 1–300 | Rolling average window for P1 meter readings |
+| Max Grid Export | W | 0 | 0–10000 | Maximum allowed grid export before charging kicks in (single-phase only) |
+
+**Options flow parameters** (set once in Configure, not entities):
+
+| Setting | Default | Purpose |
+| :--- | :--- | :--- |
+| Override Battery Capacity | OFF | Enable manual battery capacity override |
+| Battery Capacity (Wh) | 2000 | Manual capacity value (only used when override is checked) |
+| Dry-Run Mode | OFF | Engine logs decisions and fires HA events but skips all API calls |
+
+**Sensors (read-only):**
+
+| Entity | Purpose |
+| :--- | :--- |
+| EM Decision | The active decision label (e.g., `solar_charge`, `night_self_consume`) |
+| EM Last Action | Last mode command sent (e.g., `charge @ 2500W`, or `[dry-run] charge @ 2500W`) |
+| EM Status | Engine state: `running`, `stopped`, `disabled`, `cooldown`, `dry_run`, or `error` |
+| Battery Energy Available | Usable energy above SOC minimum (Wh) |
+| Hours Until Sunrise | Calculated from `sun.sun` entity |
+| Hours Until Sunset | Calculated from `sun.sun` entity |
+| P1 Average Power | Rolling average of P1 meter readings, configurable window (W) |
+
+**Binary sensors:**
+
+| Entity | Purpose |
+| :--- | :--- |
+| Night Mode Active | Whether it's currently nighttime (sun below horizon, no solar) |
+| High Load Detected | Whether home load exceeds the high load threshold |
+
+**HA Events:**
+
+The engine fires a `hyxi_em_mode_changed` event on every mode change, usable in automations:
+
+| Field | Description |
+| :--- | :--- |
+| `sn` | Inverter serial number |
+| `mode` | New mode (`charge`, `discharge`, `self_consume`, `idle`) |
+| `power` | Target power in watts (null for idle/self_consume) |
+| `previous_mode` | Mode before the change |
+| `decision` | Decision label that triggered the change |
+| `dry_run` | `true` if in dry-run mode (field absent when not dry-run) |
+
 #### Microinverter
 
 | Controls | controlId |
@@ -137,6 +357,7 @@ Click the **Configure** button on the HYXI integration card to access:
 * **Polling Interval:** Adjust frequency between 1–60 minutes (Default: 5).
 * **Enable Discovery via Alarms:** Proactively discover child devices reporting active alarms (Advanced).
 * **Enable Device Control & Protection:** Opt-in to enable inverter mode buttons, charge/discharge power settings, automatic battery protection thresholds, and micro-inverter power limits or switches. By default, this is disabled to prevent conflicts with external control systems (e.g. energy providers or grid constraints).
+* **Enable Energy Manager Standalone (Beta):** Automated battery management engine. Only visible after enabling Device Control & Protection. See [Energy Manager Standalone](#energy-manager-standalone-beta) above.
 
 ## 🛡️ Quality Assurance
 

--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -165,7 +165,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Start EM engine after platforms are loaded (entities need to exist first)
-    if getattr(coordinator, "engine", None) is not None:
+    if coordinator.engine is not None:
         await coordinator.engine.async_start()
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
@@ -177,7 +177,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     coordinator = hass.data[DOMAIN].get(entry.entry_id)
     if coordinator is not None:
-        if getattr(coordinator, "engine", None) is not None:
+        if coordinator.engine is not None:
             await coordinator.engine.async_stop()
         for controller in coordinator.protection_controllers.values():
             await controller.async_stop()

--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -17,6 +17,11 @@ from hyxi_cloud_api import __version__ as API_VERSION
 from .const import (
     BASE_URL_DEFAULT,
     CONF_ACCESS_KEY,
+    CONF_EM_ENABLED,
+    CONF_EM_FORECAST_ENTITY,
+    CONF_EM_FORECAST_POWER_ENTITY,
+    CONF_EM_INVERTER_SN,
+    CONF_EM_P1_ENTITY,
     CONF_SECRET_KEY,
     DOMAIN,
     MANUFACTURER,
@@ -132,7 +137,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _remove_legacy_select_entities(hass, coordinator.data)
     await _async_setup_battery_protection(hass, coordinator)
 
+    # Energy Manager: create engine if configured and enabled
+    em_enabled = entry.options.get(CONF_EM_ENABLED, False)
+    em_sn = entry.options.get(CONF_EM_INVERTER_SN)
+    if em_enabled and em_sn and em_sn in coordinator.data:
+        from .engine import EMEntityConfig, EnergyManagerEngine
+
+        em_config = EMEntityConfig(
+            sn=em_sn,
+            p1_entity=entry.options.get(CONF_EM_P1_ENTITY, ""),
+            forecast_entity=entry.options.get(CONF_EM_FORECAST_ENTITY),
+            forecast_power_entity=entry.options.get(CONF_EM_FORECAST_POWER_ENTITY),
+        )
+        engine = EnergyManagerEngine(hass, coordinator, em_config)
+        coordinator.engine = engine
+
+        # Register EM virtual device
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, f"{em_sn}_energy_manager")},
+            name="Energy Manager",
+            manufacturer=MANUFACTURER,
+            model="Energy Manager",
+            via_device=(DOMAIN, em_sn),
+        )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Start EM engine after platforms are loaded (entities need to exist first)
+    if getattr(coordinator, "engine", None) is not None:
+        await coordinator.engine.async_start()
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -143,6 +177,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     coordinator = hass.data[DOMAIN].get(entry.entry_id)
     if coordinator is not None:
+        if getattr(coordinator, "engine", None) is not None:
+            await coordinator.engine.async_stop()
         for controller in coordinator.protection_controllers.values():
             await controller.async_stop()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -1,18 +1,22 @@
 """Binary sensor platform for HYXI Cloud."""
 
+from __future__ import annotations
+
+from typing import ClassVar
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from hyxi_cloud_api import VPP_ACTIVE_MODES
 
-from .const import DOMAIN, MANUFACTURER
+from .const import CONF_EM_ENABLED, CONF_EM_INVERTER_SN, DOMAIN, MANUFACTURER
 
 ACTIVE_ALARM_STATES = {"0", "1", "2", 0, 1, 2}
 
@@ -37,6 +41,17 @@ async def async_setup_entry(
             entities.append(
                 HyxiVppControlSensor(coordinator, entry, device_sn, dev_data)
             )
+
+    # Energy Manager binary sensors (EM-only)
+    em_sn = entry.options.get(CONF_EM_INVERTER_SN)
+    if entry.options.get(CONF_EM_ENABLED) and em_sn and em_sn in coordinator.data:
+        em_device_info = {"identifiers": {(DOMAIN, f"{em_sn}_energy_manager")}}
+        entities.append(
+            EMBinarySensor(coordinator, em_sn, "night_mode_active", em_device_info)
+        )
+        entities.append(
+            EMBinarySensor(coordinator, em_sn, "high_load_detected", em_device_info)
+        )
 
     async_add_entities(entities)
 
@@ -256,3 +271,61 @@ class HyxiVppControlSensor(CoordinatorEntity, BinarySensorEntity):
             "vpp_manufacturer": manufacturer or "Not enrolled",
             "vpp_supplier_name": supplier or "Not enrolled",
         }
+
+
+class EMBinarySensor(BinarySensorEntity):
+    """Binary sensor backed by the Energy Manager engine."""
+
+    _attr_has_entity_name = True
+
+    _ICONS: ClassVar[dict[str, str]] = {
+        "night_mode_active": "mdi:weather-night",
+        "high_load_detected": "mdi:flash-alert",
+    }
+
+    def __init__(
+        self,
+        coordinator,
+        sn: str,
+        key: str,
+        device_info: dict,
+    ) -> None:
+        """Initialize the EM binary sensor."""
+        self._coordinator = coordinator
+        self._sn = sn
+        self._key = key
+        self._attr_unique_id = f"hyxi_{sn}_em_{key}"
+        self._attr_translation_key = f"em_{key}"
+        self._attr_device_info = device_info
+        self._attr_icon = self._ICONS.get(key)
+
+    async def async_added_to_hass(self) -> None:
+        """Register for engine updates."""
+        engine = self._coordinator.engine
+        if engine:
+            engine.register_update_callback(self._engine_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister from engine updates."""
+        engine = self._coordinator.engine
+        if engine:
+            engine.unregister_update_callback(self._engine_updated)
+
+    @callback
+    def _engine_updated(self) -> None:
+        """Handle engine state change."""
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the current value from the engine."""
+        engine = self._coordinator.engine
+        if not engine:
+            return None
+        if self._key == "night_mode_active":
+            return engine._is_night()
+        if self._key == "high_load_detected":
+            home_load = engine._get_home_load()
+            threshold = engine._get_param("high_load_threshold")
+            return home_load > threshold
+        return None

--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -45,7 +46,13 @@ async def async_setup_entry(
     # Energy Manager binary sensors (EM-only)
     em_sn = entry.options.get(CONF_EM_INVERTER_SN)
     if entry.options.get(CONF_EM_ENABLED) and em_sn and em_sn in coordinator.data:
-        em_device_info = {"identifiers": {(DOMAIN, f"{em_sn}_energy_manager")}}
+        em_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{em_sn}_energy_manager")},
+            name="Energy Manager",
+            manufacturer=MANUFACTURER,
+            model="Energy Manager",
+            via_device=(DOMAIN, em_sn),
+        )
         entities.append(
             EMBinarySensor(coordinator, em_sn, "night_mode_active", em_device_info)
         )
@@ -288,7 +295,7 @@ class EMBinarySensor(BinarySensorEntity):
         coordinator,
         sn: str,
         key: str,
-        device_info: dict,
+        device_info: DeviceInfo,
     ) -> None:
         """Initialize the EM binary sensor."""
         self._coordinator = coordinator

--- a/custom_components/hyxi_cloud/config_flow.py
+++ b/custom_components/hyxi_cloud/config_flow.py
@@ -14,8 +14,19 @@ from .const import (
     BASE_URL_DEFAULT,
     CONF_ACCESS_KEY,
     CONF_BACK_DISCOVERY,
+    CONF_EM_BATTERY_CAPACITY,
+    CONF_EM_BATTERY_OVERRIDE,
+    CONF_EM_DRY_RUN,
+    CONF_EM_ENABLED,
+    CONF_EM_FORECAST_ENTITY,
+    CONF_EM_FORECAST_POWER_ENTITY,
+    CONF_EM_INVERTER_SN,
+    CONF_EM_LOOP_INTERVAL,
+    CONF_EM_P1_ENTITY,
     CONF_SECRET_KEY,
     DOMAIN,
+    get_raw_device_code,
+    normalize_device_type,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,41 +151,198 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
         self._config_entry = config_entry
+        self._options: dict = {}
 
     async def async_step_init(self, user_input=None):
         """Manage the options form."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            # Preserve all existing options, update with new values
+            self._options = dict(self._config_entry.options)
+            self._options["update_interval"] = user_input["update_interval"]
+            self._options[CONF_BACK_DISCOVERY] = user_input.get(
+                CONF_BACK_DISCOVERY, False
+            )
+            self._options["enable_battery_control"] = user_input.get(
+                "enable_battery_control", False
+            )
+            enable_em = user_input.get("enable_energy_manager", False)
+
+            # EM requires battery control — auto-enable if user turned on EM
+            if enable_em and not self._options.get("enable_battery_control"):
+                self._options["enable_battery_control"] = True
+
+            if enable_em:
+                self._options[CONF_EM_ENABLED] = True
+                return await self.async_step_energy_manager()
+
+            # EM disabled — remove EM keys if they were previously set
+            self._options.pop(CONF_EM_ENABLED, None)
+            for key in (
+                CONF_EM_INVERTER_SN,
+                CONF_EM_P1_ENTITY,
+                CONF_EM_FORECAST_ENTITY,
+                CONF_EM_FORECAST_POWER_ENTITY,
+                CONF_EM_BATTERY_OVERRIDE,
+                CONF_EM_BATTERY_CAPACITY,
+                CONF_EM_LOOP_INTERVAL,
+                CONF_EM_DRY_RUN,
+            ):
+                self._options.pop(key, None)
+            return self.async_create_entry(title="", data=self._options)
 
         # Pull current values or defaults
         current_interval = self._config_entry.options.get("update_interval", 5)
+        em_enabled = self._config_entry.options.get(CONF_EM_ENABLED, False)
+        has_controllable = self._has_controllable_inverter()
 
-        from .const import is_battery_control_enabled
+        schema_dict = {
+            # Slider for Interval
+            vol.Required("update_interval", default=current_interval): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=60)
+            ),
+            # Toggle for Alarm-based discovery
+            vol.Optional(
+                CONF_BACK_DISCOVERY,
+                default=self._config_entry.options.get(CONF_BACK_DISCOVERY, False),
+            ): selector.BooleanSelector(),
+        }
 
-        coordinator = None
-        if hasattr(self, "hass") and self.hass:
-            coordinator = self.hass.data.get(DOMAIN, {}).get(
-                self._config_entry.entry_id
+        # Only show control/EM toggles if controllable inverters exist
+        if has_controllable:
+            battery_control_on = self._config_entry.options.get(
+                "enable_battery_control", False
             )
-        default_control = is_battery_control_enabled(self._config_entry, coordinator)
-
-        options_schema = vol.Schema(
-            {
-                # Slider for Interval
-                vol.Required("update_interval", default=current_interval): vol.All(
-                    vol.Coerce(int), vol.Range(min=1, max=60)
-                ),
-                # Toggle for Alarm-based discovery
-                vol.Optional(
-                    CONF_BACK_DISCOVERY,
-                    default=self._config_entry.options.get(CONF_BACK_DISCOVERY, False),
-                ): selector.BooleanSelector(),
-                # Toggle for Battery Control & Protection
+            schema_dict[
                 vol.Optional(
                     "enable_battery_control",
-                    default=default_control,
+                    default=battery_control_on,
+                )
+            ] = selector.BooleanSelector()
+            # EM toggle only visible when battery control is already enabled
+            if battery_control_on:
+                schema_dict[
+                    vol.Optional("enable_energy_manager", default=em_enabled)
+                ] = selector.BooleanSelector()
+
+        return self.async_show_form(step_id="init", data_schema=vol.Schema(schema_dict))
+
+    async def async_step_energy_manager(self, user_input=None):
+        """Configure the Energy Manager -- P1 entity, forecast, inverter SN."""
+        if user_input is not None:
+            self._options[CONF_EM_P1_ENTITY] = user_input[CONF_EM_P1_ENTITY]
+            self._options[CONF_EM_INVERTER_SN] = user_input[CONF_EM_INVERTER_SN]
+            self._options[CONF_EM_BATTERY_OVERRIDE] = user_input.get(
+                CONF_EM_BATTERY_OVERRIDE, False
+            )
+            if user_input.get(CONF_EM_BATTERY_OVERRIDE):
+                self._options[CONF_EM_BATTERY_CAPACITY] = user_input.get(
+                    CONF_EM_BATTERY_CAPACITY, 2000
+                )
+            else:
+                self._options.pop(CONF_EM_BATTERY_CAPACITY, None)
+            if user_input.get(CONF_EM_FORECAST_ENTITY):
+                self._options[CONF_EM_FORECAST_ENTITY] = user_input[
+                    CONF_EM_FORECAST_ENTITY
+                ]
+            if user_input.get(CONF_EM_FORECAST_POWER_ENTITY):
+                self._options[CONF_EM_FORECAST_POWER_ENTITY] = user_input[
+                    CONF_EM_FORECAST_POWER_ENTITY
+                ]
+            self._options[CONF_EM_LOOP_INTERVAL] = user_input.get(
+                CONF_EM_LOOP_INTERVAL, 15
+            )
+            self._options[CONF_EM_DRY_RUN] = user_input.get(CONF_EM_DRY_RUN, False)
+            return self.async_create_entry(title="", data=self._options)
+
+        # Build inverter SN options from coordinator data
+        sn_options = self._get_controllable_sns()
+        current_sn = self._config_entry.options.get(CONF_EM_INVERTER_SN, "")
+        if not current_sn and len(sn_options) == 1:
+            current_sn = sn_options[0]
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_EM_P1_ENTITY,
+                    default=self._config_entry.options.get(CONF_EM_P1_ENTITY, ""),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
+                vol.Optional(
+                    CONF_EM_FORECAST_ENTITY,
+                    default=self._config_entry.options.get(CONF_EM_FORECAST_ENTITY, ""),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
+                vol.Optional(
+                    CONF_EM_FORECAST_POWER_ENTITY,
+                    default=self._config_entry.options.get(
+                        CONF_EM_FORECAST_POWER_ENTITY, ""
+                    ),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
+                vol.Required(
+                    CONF_EM_INVERTER_SN, default=current_sn
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=sn_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+                vol.Optional(
+                    CONF_EM_BATTERY_OVERRIDE,
+                    default=self._config_entry.options.get(
+                        CONF_EM_BATTERY_OVERRIDE, False
+                    ),
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    CONF_EM_BATTERY_CAPACITY,
+                    default=self._config_entry.options.get(
+                        CONF_EM_BATTERY_CAPACITY, 2000
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1000,
+                        max=50000,
+                        step=100,
+                        unit_of_measurement="Wh",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                vol.Optional(
+                    CONF_EM_LOOP_INTERVAL,
+                    default=self._config_entry.options.get(CONF_EM_LOOP_INTERVAL, 15),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=5,
+                        max=60,
+                        step=1,
+                        unit_of_measurement="s",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                vol.Optional(
+                    CONF_EM_DRY_RUN,
+                    default=self._config_entry.options.get(CONF_EM_DRY_RUN, False),
                 ): selector.BooleanSelector(),
             }
         )
 
-        return self.async_show_form(step_id="init", data_schema=options_schema)
+        return self.async_show_form(step_id="energy_manager", data_schema=schema)
+
+    def _get_controllable_sns(self) -> list[str]:
+        """Get serial numbers of controllable inverters from coordinator data."""
+        coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        if not coordinator or not coordinator.data:
+            return []
+        sns = []
+        for sn, dev_data in coordinator.data.items():
+            device_type = normalize_device_type(get_raw_device_code(dev_data))
+            if device_type in ("hybrid_inverter", "all_in_one"):
+                sns.append(sn)
+        return sns
+
+    def _has_controllable_inverter(self) -> bool:
+        """Check if any controllable inverter exists."""
+        return len(self._get_controllable_sns()) > 0

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -212,3 +212,35 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SWITCH,
 ]
+
+
+# Energy Manager option keys
+CONF_EM_ENABLED = "em_enabled"
+CONF_EM_INVERTER_SN = "em_inverter_sn"
+CONF_EM_P1_ENTITY = "em_p1_entity"
+CONF_EM_FORECAST_ENTITY = "em_forecast_entity"
+CONF_EM_FORECAST_POWER_ENTITY = "em_forecast_power_entity"
+CONF_EM_BATTERY_OVERRIDE = "em_battery_capacity_override"
+CONF_EM_BATTERY_CAPACITY = "em_battery_capacity_wh"
+CONF_EM_DRY_RUN = "em_dry_run"
+CONF_EM_LOOP_INTERVAL = "em_loop_interval"
+
+# EM parameter defaults (match pyscript values)
+EM_DEFAULTS: dict[str, int | float] = {
+    "high_load_threshold": 6500,
+    "max_charge_power": 5000,
+    "max_discharge_power": 5000,
+    "min_solar_for_charge": 1000,
+    "mode_switch_cooldown": 60,
+    "power_change_threshold": 100,
+    "power_adjust_cooldown": 30,
+    "night_buffer_pct": 5,
+    "avg_night_consumption": 400,
+    "charge_margin": 150,
+    "charge_entry_threshold": 500,
+    "charge_reentry_delay": 300,
+    "bottomout_cooldown": 300,
+    "p1_smoothing_period": 60,
+    "max_grid_export": 0,
+}
+EM_LOOP_INTERVAL = 15  # seconds

--- a/custom_components/hyxi_cloud/coordinator.py
+++ b/custom_components/hyxi_cloud/coordinator.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import Any, TypedDict
 
 from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
@@ -21,9 +21,6 @@ from .const import (
     mask_sn,
     normalize_device_type,
 )
-
-if TYPE_CHECKING:
-    from .engine import EnergyManagerEngine
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,7 +57,7 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
         self.client = client
         self.entry = entry
         self.protection_controllers: dict[str, Any] = {}
-        self.engine: EnergyManagerEngine | None = None
+        self.engine: Any = None
 
         # 🚀 Store metadata on the object, not in the data dictionary!
         self.hyxi_metadata: HyxiMetadata = {

--- a/custom_components/hyxi_cloud/coordinator.py
+++ b/custom_components/hyxi_cloud/coordinator.py
@@ -99,7 +99,9 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
                     "from the app to the developer email first."
                 )
 
-            # Raise UpdateFailed if all non-collector devices return empty telemetry metrics.
+            # Warn (but don't fail) when telemetry is empty.
+            # Raising UpdateFailed here triggers HA exponential backoff,
+            # which compounds polling delays and causes stale-data perception.
             non_collectors = [
                 dev_data
                 for dev_data in devices.values()
@@ -109,7 +111,10 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
                 not (set(dev_data.get("metrics") or {}) - {"last_seen"})
                 for dev_data in non_collectors
             ):
-                raise UpdateFailed("HYXI telemetry data is currently unavailable.")
+                _LOGGER.warning(
+                    "HYXI Cloud returned success but telemetry metrics are empty. "
+                    "Sensors may show stale values until next successful poll."
+                )
 
             self.hyxi_metadata["last_attempts"] = result.get("attempts", 1)
             self.hyxi_metadata["last_success"] = dt_util.utcnow()

--- a/custom_components/hyxi_cloud/coordinator.py
+++ b/custom_components/hyxi_cloud/coordinator.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +21,9 @@ from .const import (
     mask_sn,
     normalize_device_type,
 )
+
+if TYPE_CHECKING:
+    from .engine import EnergyManagerEngine
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +60,7 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
         self.client = client
         self.entry = entry
         self.protection_controllers: dict[str, Any] = {}
+        self.engine: EnergyManagerEngine | None = None
 
         # 🚀 Store metadata on the object, not in the data dictionary!
         self.hyxi_metadata: HyxiMetadata = {

--- a/custom_components/hyxi_cloud/engine.py
+++ b/custom_components/hyxi_cloud/engine.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 import logging
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from homeassistant.components import persistent_notification
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import (
@@ -110,6 +112,8 @@ class EnergyManagerEngine:
         self._last_mode_switch: float = 0
         self._last_decision: str = ""
         self._last_action: str = ""
+        self._in_decision: bool = False
+        self._last_fast_path_trigger: float = 0
         self._last_power_adjust: float = 0
         self._last_charge_exit: float = 0
         self._last_bottomout_exit: float = 0
@@ -130,7 +134,7 @@ class EnergyManagerEngine:
         self._unsub_listeners: list[CALLBACK_TYPE] = []
 
         # Sensor update callbacks
-        self._update_callbacks: list[callback] = []
+        self._update_callbacks: list[Callable[[], None]] = []
 
     # ── Properties for sensor entities ──────────────────────────────────
 
@@ -246,11 +250,11 @@ class EnergyManagerEngine:
         _LOGGER.info("Energy Manager stopped for %s", mask_sn(self._sn))
         self._notify_sensors()
 
-    def register_update_callback(self, cb: callback) -> None:
+    def register_update_callback(self, cb: Callable[[], None]) -> None:
         """Register a callback for sensor updates after each decision."""
         self._update_callbacks.append(cb)
 
-    def unregister_update_callback(self, cb: callback) -> None:
+    def unregister_update_callback(self, cb: Callable[[], None]) -> None:
         """Remove a sensor update callback."""
         if cb in self._update_callbacks:
             self._update_callbacks.remove(cb)
@@ -709,57 +713,66 @@ class EnergyManagerEngine:
           4b. Night preservation -> idle if SOC <= night target
           5. Solar optimization -> self_consume first, charge on sustained export
         """
-        # Read soc_min/soc_max from EXISTING protection number entities
-        solar = self._get_solar()
-        s = DecisionState(
-            soc=self._get_soc(),
-            solar=solar,
-            p1=self._get_p1(),
-            home_load=self._get_home_load(),
-            soc_min=self._get_protection_param("soc_min", 20),
-            soc_max=self._get_protection_param("soc_max", 90),
-            max_charge=self._get_param("max_charge_power"),
-            max_discharge=self._get_param("max_discharge_power"),
-            is_night=self._is_night(),
-            solar_producing=solar > 50,
-            night_soc_target=self._soc_needed_for_night(),
-        )
-
-        _LOGGER.debug(
-            "EM TICK: SOC=%.0f%% P1=%.0fW solar=%.0fW load=%.0fW "
-            "night=%s night_target=%.0f%%",
-            s.soc,
-            s.p1,
-            s.solar,
-            s.home_load,
-            s.is_night,
-            s.night_soc_target,
-        )
-
-        # PRIORITY 1 & 2: SOC safety limits
-        if await self._check_soc_limits(s):
+        if self._in_decision:
+            _LOGGER.debug(
+                "EM: Decision engine already executing, skipping concurrent run"
+            )
             return
+        self._in_decision = True
+        try:
+            # Read soc_min/soc_max from EXISTING protection number entities
+            solar = self._get_solar()
+            s = DecisionState(
+                soc=self._get_soc(),
+                solar=solar,
+                p1=self._get_p1(),
+                home_load=self._get_home_load(),
+                soc_min=self._get_protection_param("soc_min", 20),
+                soc_max=self._get_protection_param("soc_max", 90),
+                max_charge=self._get_param("max_charge_power"),
+                max_discharge=self._get_param("max_discharge_power"),
+                is_night=self._is_night(),
+                solar_producing=solar > 50,
+                night_soc_target=self._soc_needed_for_night(),
+            )
 
-        # PRIORITY 2b: Export limiting
-        if await self._check_export_limit(s):
-            return
+            _LOGGER.debug(
+                "EM TICK: SOC=%.0f%% P1=%.0fW solar=%.0fW load=%.0fW "
+                "night=%s night_target=%.0f%%",
+                s.soc,
+                s.p1,
+                s.solar,
+                s.home_load,
+                s.is_night,
+                s.night_soc_target,
+            )
 
-        # PRIORITY 3: Sustained high load
-        if await self._check_high_load(s):
-            return
+            # PRIORITY 1 & 2: SOC safety limits
+            if await self._check_soc_limits(s):
+                return
 
-        # PRIORITY 4 & 4b: Night mode
-        if await self._check_night(s):
-            return
+            # PRIORITY 2b: Export limiting
+            if await self._check_export_limit(s):
+                return
 
-        # PRIORITY 5: Solar optimization
-        if await self._check_solar(s):
-            return
+            # PRIORITY 3: Sustained high load
+            if await self._check_high_load(s):
+                return
 
-        # ── DEFAULT: self_consume as safe fallback ─────────────────────
-        self._set_decision("idle_default")
-        if self._current_mode in ("charge", "discharge"):
-            await self._set_mode("self_consume")
+            # PRIORITY 4 & 4b: Night mode
+            if await self._check_night(s):
+                return
+
+            # PRIORITY 5: Solar optimization
+            if await self._check_solar(s):
+                return
+
+            # ── DEFAULT: self_consume as safe fallback ─────────────────────
+            self._set_decision("idle_default")
+            if self._current_mode in ("charge", "discharge"):
+                await self._set_mode("self_consume")
+        finally:
+            self._in_decision = False
 
     async def _check_soc_limits(self, s: DecisionState) -> bool:
         """PRIORITY 1 & 2: SOC safety limits. Returns True if handled."""
@@ -1115,7 +1128,8 @@ class EnergyManagerEngine:
                     "EM: Coordinator data stale (%.0f min) — reloading integration",
                     stale_seconds / 60,
                 )
-                self._hass.components.persistent_notification.async_create(
+                persistent_notification.async_create(
+                    self._hass,
                     f"Energy Manager detected stale data ({stale_seconds / 60:.0f} min). "
                     "Auto-reloading integration to restore updates.",
                     title="HYXI Cloud: Stale Data",
@@ -1182,7 +1196,10 @@ class EnergyManagerEngine:
         home_load = self._get_home_load()
         threshold = self._get_param("high_load_threshold")
         if home_load > threshold:
-            self._hass.async_create_task(self._make_decision())
+            now = time.monotonic()
+            if now - self._last_fast_path_trigger >= 15:
+                self._last_fast_path_trigger = now
+                self._hass.async_create_task(self._make_decision())
 
     @callback
     def _on_soc_change(self, event) -> None:
@@ -1201,16 +1218,19 @@ class EnergyManagerEngine:
 
         soc_min = self._get_protection_param("soc_min", 20)
         if soc < soc_min:
-            self._hass.async_create_task(self._make_decision())
+            now = time.monotonic()
+            if now - self._last_fast_path_trigger >= 15:
+                self._last_fast_path_trigger = now
+                self._hass.async_create_task(self._make_decision())
 
     async def _update_night_estimate(self, now) -> None:
         """Hourly night consumption update — EMA from P1 readings at night."""
         if not self._enabled:
             return
 
-        from datetime import datetime as dt
+        from homeassistant.util import dt as dt_util
 
-        hour = dt.now().hour
+        hour = dt_util.now().hour
         if 21 <= hour or hour < 6:
             current_p1 = self._get_p1()
             if current_p1 > 0:

--- a/custom_components/hyxi_cloud/engine.py
+++ b/custom_components/hyxi_cloud/engine.py
@@ -1,0 +1,1223 @@
+# pylint: disable=too-many-lines
+"""Energy Manager — decision engine for automated battery control.
+
+Manages battery charging and operating mode based on:
+  - Real-time P1 meter and solar production
+  - Battery SOC limits (read from existing protection numbers)
+  - Solar forecast predictions (sunset urgency)
+  - High-load detection with battery assist
+
+Modes used:
+  - self_consume: default — inverter discharges to offset house load
+  - charge: actively charge battery from solar excess
+  - discharge: only used when SOC exceeds maximum
+  - idle: stop all battery activity (night reserve depleted, unsafe high load)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+    async_track_time_interval,
+)
+from hyxi_cloud_api import HyxiApiClient
+
+from .const import (
+    CONF_EM_LOOP_INTERVAL,
+    DOMAIN,
+    EM_DEFAULTS,
+    EM_LOOP_INTERVAL,
+    detect_phase_type,
+    get_raw_device_code,
+    mask_sn,
+    normalize_device_type,
+)
+
+if TYPE_CHECKING:
+    from .coordinator import HyxiDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Default rolling average window for P1 readings (overridable via p1_smoothing_period param)
+_P1_SMOOTHING_DEFAULT = 60
+
+
+@dataclass
+class EMEntityConfig:
+    """Entity configuration for the Energy Manager engine."""
+
+    sn: str
+    p1_entity: str
+    forecast_entity: str | None = None
+    forecast_power_entity: str | None = None
+
+
+@dataclass
+class DecisionState:
+    """Snapshot of current system state for the decision engine."""
+
+    soc: float
+    solar: float
+    p1: float
+    home_load: float
+    soc_min: float
+    soc_max: float
+    max_charge: float
+    max_discharge: float
+    is_night: bool
+    solar_producing: bool
+    night_soc_target: float
+
+
+@dataclass
+class SolarConfig:
+    """Computed solar charge parameters for a single decision tick."""
+
+    min_solar_for_charge: float
+    charge_margin: float
+    charge_entry_threshold: float
+    readings_needed: int
+    sunset_urgent: bool
+
+
+class EnergyManagerEngine:
+    """Decision engine for automated battery management."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: HyxiDataUpdateCoordinator,
+        config: EMEntityConfig,
+    ) -> None:
+        """Initialize the energy manager engine."""
+        self._hass = hass
+        self._coordinator = coordinator
+        self._sn = config.sn
+        self._p1_entity = config.p1_entity
+        self._forecast_entity = config.forecast_entity
+        self._forecast_power_entity = config.forecast_power_entity
+
+        # State tracking
+        self._last_mode_switch: float = 0
+        self._last_decision: str = ""
+        self._last_action: str = ""
+        self._last_power_adjust: float = 0
+        self._last_charge_exit: float = 0
+        self._last_bottomout_exit: float = 0
+        self._charge_entry_export_count: int = 0
+        self._charge_bottomout_count: int = 0
+        self._current_mode: str | None = None
+        self._last_sent_power: dict[str, int] = {"charge": 0, "discharge": 0}
+
+        # PV curtailment state (peak shaving stop/hold cycling)
+        self._pv_curtailed: bool = False
+        self._last_pv_curtail_toggle: float = 0
+
+        # P1 rolling average
+        self._p1_buffer: deque[tuple[float, float]] = deque()
+
+        # Lifecycle
+        self._enabled: bool = False
+        self._unsub_listeners: list[CALLBACK_TYPE] = []
+
+        # Sensor update callbacks
+        self._update_callbacks: list[callback] = []
+
+    # ── Properties for sensor entities ──────────────────────────────────
+
+    @property
+    def status(self) -> str:
+        """Engine status: running, stopped, disabled, cooldown, error."""
+        if not self._enabled:
+            return "stopped"
+        # Check if em_enabled switch is off
+        em_enabled_uid = f"hyxi_{self._sn}_em_enabled"
+        em_entity = self._find_entity_id("switch", em_enabled_uid)
+        if em_entity and not self._get_ha_state_bool(em_entity, True):
+            return "disabled"
+        if self._last_decision == "error":
+            return "error"
+        cooldown = self._get_param("mode_switch_cooldown")
+        if (time.monotonic() - self._last_mode_switch) < cooldown:
+            return "cooldown"
+        if self._dry_run:
+            return "dry_run"
+        return "running"
+
+    @property
+    def decision(self) -> str:
+        """Current decision label."""
+        return self._last_decision
+
+    @property
+    def last_action(self) -> str:
+        """Last action taken."""
+        return self._last_action
+
+    @property
+    def current_mode(self) -> str | None:
+        """Last mode set by the engine."""
+        return self._current_mode
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the engine loop is running."""
+        return self._enabled
+
+    @property
+    def p1_avg(self) -> float:
+        """Rolling 1-minute average of P1 readings."""
+        if not self._p1_buffer:
+            return 0.0
+        return sum(v for _, v in self._p1_buffer) / len(self._p1_buffer)
+
+    # ── Lifecycle ───────────────────────────────────────────────────────
+
+    async def async_start(self) -> None:
+        """Start the engine loop and state listeners."""
+        if self._enabled:
+            return
+
+        self._enabled = True
+        _LOGGER.info("Energy Manager started for %s", mask_sn(self._sn))
+
+        # Decision loop — interval from options or default
+        interval = int(
+            self._coordinator.entry.options.get(CONF_EM_LOOP_INTERVAL, EM_LOOP_INTERVAL)
+        )
+        self._unsub_listeners.append(
+            async_track_time_interval(
+                self._hass,
+                self._loop_tick,
+                timedelta(seconds=interval),
+            )
+        )
+
+        # P1 state change listener for rolling average + high-load fast-path
+        if self._p1_entity:
+            self._unsub_listeners.append(
+                async_track_state_change_event(
+                    self._hass,
+                    [self._p1_entity],
+                    self._on_p1_change,
+                )
+            )
+
+        # Low-SOC fast-path: listen for battery SOC changes
+        soc_entity = self._find_entity_id("sensor", f"hyxi_{self._sn}_batsoc")
+        if soc_entity:
+            self._unsub_listeners.append(
+                async_track_state_change_event(
+                    self._hass,
+                    [soc_entity],
+                    self._on_soc_change,
+                )
+            )
+
+        # Hourly night consumption estimate
+        self._unsub_listeners.append(
+            async_track_time_interval(
+                self._hass,
+                self._update_night_estimate,
+                timedelta(hours=1),
+            )
+        )
+
+        self._notify_sensors()
+
+    async def async_stop(self) -> None:
+        """Stop the engine loop and all listeners."""
+        if not self._enabled:
+            return
+
+        self._enabled = False
+        for unsub in self._unsub_listeners:
+            unsub()
+        self._unsub_listeners.clear()
+        _LOGGER.info("Energy Manager stopped for %s", mask_sn(self._sn))
+        self._notify_sensors()
+
+    def register_update_callback(self, cb: callback) -> None:
+        """Register a callback for sensor updates after each decision."""
+        self._update_callbacks.append(cb)
+
+    def unregister_update_callback(self, cb: callback) -> None:
+        """Remove a sensor update callback."""
+        if cb in self._update_callbacks:
+            self._update_callbacks.remove(cb)
+
+    def _notify_sensors(self) -> None:
+        """Notify all registered sensor entities to update."""
+        for cb in self._update_callbacks:
+            cb()
+
+    # ── State reading helpers ───────────────────────────────────────────
+
+    def _find_entity_id(self, domain: str, unique_id: str) -> str | None:
+        """Look up an entity_id by unique_id via the entity registry."""
+        registry = er.async_get(self._hass)
+        return registry.async_get_entity_id(domain, DOMAIN, unique_id)
+
+    def _get_coordinator_metric(self, key: str, default: float = 0.0) -> float:
+        """Get a metric value from the coordinator data."""
+        if not self._coordinator.data:
+            return default
+        dev_data = self._coordinator.data.get(self._sn)
+        if not dev_data:
+            return default
+        metrics = dev_data.get("metrics") or {}
+        val = metrics.get(key)
+        if val is None:
+            return default
+        try:
+            return float(val)
+        except ValueError, TypeError:
+            return default
+
+    def _get_ha_state_float(self, entity_id: str | None, default: float = 0.0) -> float:
+        """Get a float value from an HA entity state."""
+        if not entity_id:
+            return default
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable", ""):
+            return default
+        try:
+            return float(state.state)
+        except ValueError, TypeError:
+            return default
+
+    def _get_ha_state_bool(self, entity_id: str | None, default: bool = False) -> bool:
+        """Get a boolean from an HA switch entity state."""
+        if not entity_id:
+            return default
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state in ("unknown", "unavailable"):
+            return default
+        return state.state == "on"
+
+    def _get_battery_capacity(self) -> float:
+        """Get battery capacity in Wh.
+
+        Priority: options override → batCap API metric → 2000 Wh fallback.
+        """
+        options = self._coordinator.entry.options
+        if options.get("em_battery_capacity_override"):
+            cap = options.get("em_battery_capacity_wh", 2000)
+            try:
+                return float(cap)
+            except ValueError, TypeError:
+                pass
+        api_cap = self._get_coordinator_metric("batCap", 0)
+        if api_cap > 0:
+            return api_cap * 1000  # kWh -> Wh
+        return 2000.0
+
+    def _get_param(self, key: str) -> float:
+        """Read a parameter value from its EM number/switch entity."""
+        if key == "battery_capacity_wh":
+            return self._get_battery_capacity()
+
+        default = EM_DEFAULTS.get(key, 0)
+        unique_id = f"hyxi_{self._sn}_em_{key}"
+        entity_id = self._find_entity_id("number", unique_id)
+        if not entity_id:
+            # Try switch domain for boolean params
+            entity_id = self._find_entity_id("switch", unique_id)
+            if entity_id:
+                return 1.0 if self._get_ha_state_bool(entity_id) else 0.0
+            return float(default)
+        return self._get_ha_state_float(entity_id, float(default))
+
+    def _has_peak_shaving(self) -> bool:
+        """Check if device supports peak shaving (controlId 1021).
+
+        Peak shaving is single-phase only. Devices with this control can
+        use 'stop' to curtail PV production when export limit is reached
+        and the battery is full.
+        """
+        if not self._coordinator.data:
+            return False
+        dev_data = self._coordinator.data.get(self._sn)
+        if not dev_data:
+            return False
+        device_type = normalize_device_type(get_raw_device_code(dev_data))
+        phase = detect_phase_type(dev_data)
+        return phase == "single_phase" and device_type in (
+            "hybrid_inverter",
+            "all_in_one",
+        )
+
+    def _get_protection_param(self, key: str, default: float) -> float:
+        """Read a value from the existing protection number entities."""
+        unique_id = f"hyxi_{self._sn}_{key}"
+        entity_id = self._find_entity_id("number", unique_id)
+        if not entity_id:
+            return default
+        return self._get_ha_state_float(entity_id, default)
+
+    def _get_soc(self) -> float:
+        """Get battery state of charge."""
+        return self._get_coordinator_metric("batSoc", 50)
+
+    def _get_solar(self) -> float:
+        """Get current solar power."""
+        return self._get_coordinator_metric("ppv", 0)
+
+    def _get_home_load(self) -> float:
+        """Get current home load."""
+        return self._get_coordinator_metric("home_load", 0)
+
+    def _get_p1(self) -> float:
+        """Get current P1 meter reading (positive=import, negative=export)."""
+        return self._get_ha_state_float(self._p1_entity, 0)
+
+    def _is_night(self) -> bool:
+        """Check if it's nighttime (no solar and sun below horizon)."""
+        solar = self._get_solar()
+        if solar > 50:
+            return False
+        sun_state = self._hass.states.get("sun.sun")
+        if sun_state is None:
+            return solar < 50
+        elevation = sun_state.attributes.get("elevation", 0)
+        return elevation < 0
+
+    def _hours_until_sunrise(self) -> float:
+        """Calculate hours until next sunrise from sun.sun attributes."""
+        sun_state = self._hass.states.get("sun.sun")
+        if sun_state is None:
+            return 12.0
+        next_rising = sun_state.attributes.get("next_rising")
+        if next_rising is None:
+            return 12.0
+        from homeassistant.util import dt as dt_util
+
+        now = dt_util.utcnow()
+        if isinstance(next_rising, str):
+            next_rising = dt_util.parse_datetime(next_rising)
+        if next_rising is None:
+            return 12.0
+        diff = (next_rising - now).total_seconds() / 3600
+        return max(0.0, diff)
+
+    def _hours_until_sunset(self) -> float:
+        """Calculate hours until next sunset from sun.sun attributes."""
+        sun_state = self._hass.states.get("sun.sun")
+        if sun_state is None:
+            return 12.0
+        next_setting = sun_state.attributes.get("next_setting")
+        if next_setting is None:
+            return 12.0
+        from homeassistant.util import dt as dt_util
+
+        now = dt_util.utcnow()
+        if isinstance(next_setting, str):
+            next_setting = dt_util.parse_datetime(next_setting)
+        if next_setting is None:
+            return 12.0
+        diff = (next_setting - now).total_seconds() / 3600
+        return max(0.0, diff)
+
+    # ── Protection integration ─────────────────────────────────────────
+
+    def _get_protection_controller(self):
+        """Get the existing battery protection controller for this SN."""
+        return self._coordinator.protection_controllers.get(self._sn)
+
+    def _notify_protection(self, mode: str) -> None:
+        """Notify the protection controller about a mode change."""
+        if controller := self._get_protection_controller():
+            controller.note_manual_mode(mode)
+
+    # ── Control methods: direct API calls matching stateless button controls ──
+
+    @property
+    def _dry_run(self) -> bool:
+        """Check if dry-run mode is enabled in options."""
+        return bool(self._coordinator.entry.options.get("em_dry_run", False))
+
+    async def _set_mode(self, mode: str, power_w: int | None = None) -> bool:
+        """Set operating mode via direct API call with cooldown enforcement."""
+        cooldown = self._get_param("mode_switch_cooldown")
+        if (time.monotonic() - self._last_mode_switch) < cooldown:
+            _LOGGER.debug("EM: Mode switch to %s blocked by cooldown", mode)
+            return False
+
+        if mode in ("charge", "discharge"):
+            power_w = int(max(1, min(power_w or 100, 10000)))
+
+        if self._dry_run:
+            action = f"{mode} @ {power_w}W" if power_w else mode
+            _LOGGER.info(
+                "EM DRY-RUN: Would set mode -> %s for %s", action, mask_sn(self._sn)
+            )
+            self._last_mode_switch = time.monotonic()
+            prev_mode = self._current_mode
+            self._current_mode = mode
+            self._last_action = f"[dry-run] {action}"
+            self._hass.bus.async_fire(
+                "hyxi_em_mode_changed",
+                {
+                    "sn": self._sn,
+                    "mode": mode,
+                    "power": power_w,
+                    "previous_mode": prev_mode,
+                    "decision": self._last_decision,
+                    "dry_run": True,
+                },
+            )
+            self._notify_sensors()
+            return True
+
+        client: HyxiApiClient = self._coordinator.client
+        try:
+            if mode == "idle":
+                await client.set_mode_idle(self._sn)
+            elif mode == "charge":
+                await client.set_mode_charge(self._sn, power_w)
+            elif mode == "discharge":
+                await client.set_mode_discharge(self._sn, power_w)
+            elif mode == "self_consume":
+                await client.set_mode_self_consume(self._sn)
+            else:
+                _LOGGER.error("EM: Unknown mode: %s", mode)
+                return False
+
+            self._last_mode_switch = time.monotonic()
+            prev_mode = self._current_mode
+            self._current_mode = mode
+            if power_w and mode in ("charge", "discharge"):
+                self._last_sent_power[mode] = power_w
+            action = f"{mode} @ {power_w}W" if power_w else mode
+            self._last_action = action
+            _LOGGER.info("EM: Mode -> %s", action)
+
+            # Fire HA event for automations / logging
+            self._hass.bus.async_fire(
+                "hyxi_em_mode_changed",
+                {
+                    "sn": self._sn,
+                    "mode": mode,
+                    "power": power_w,
+                    "previous_mode": prev_mode,
+                    "decision": self._last_decision,
+                },
+            )
+
+            # Notify protection controller about the mode change
+            self._notify_protection(mode)
+
+            return True
+
+        except HyxiApiClient.ControlError as err:
+            _LOGGER.error("EM: Failed to set mode %s: %s", mode, err)
+            return False
+
+    async def _adjust_power(self, direction: str, target_w: int) -> bool:
+        """Adjust charge/discharge power and resend command to inverter."""
+        adjust_cooldown = self._get_param("power_adjust_cooldown")
+        if (time.monotonic() - self._last_power_adjust) < adjust_cooldown:
+            return False
+
+        target_w = int(max(1, min(target_w, 10000)))
+        threshold = self._get_param("power_change_threshold")
+
+        # Check if power actually changed enough
+        current_power = self._get_current_power_setting(direction)
+        if abs(target_w - current_power) <= threshold and target_w > 100:
+            return False
+
+        if self._dry_run:
+            _LOGGER.info(
+                "EM DRY-RUN: Would adjust %s power -> %dW for %s",
+                direction,
+                target_w,
+                mask_sn(self._sn),
+            )
+            self._last_power_adjust = time.monotonic()
+            self._current_mode = direction
+            return True
+
+        client: HyxiApiClient = self._coordinator.client
+        try:
+            if direction == "charge":
+                await client.set_mode_charge(self._sn, target_w)
+            else:
+                await client.set_mode_discharge(self._sn, target_w)
+
+            self._last_power_adjust = time.monotonic()
+            self._current_mode = direction
+            self._last_sent_power[direction] = target_w
+            self._last_action = f"{direction} @ {target_w}W"
+            _LOGGER.debug("EM: %s power -> %dW", direction, target_w)
+
+            # Notify protection controller about the mode change
+            self._notify_protection(direction)
+            self._notify_sensors()
+
+            return True
+
+        except HyxiApiClient.ControlError as err:
+            _LOGGER.error("EM: Failed to adjust %s power: %s", direction, err)
+            return False
+
+    async def _set_peak_shaving(self, option: str) -> bool:
+        """Send a peak shaving command (stop/hold) with cooldown.
+
+        Used for PV curtailment on single-phase devices when battery is full
+        and export exceeds limit. Minimum 30s between toggles to prevent
+        oscillation.
+        """
+        pv_curtail_cooldown = 30
+        if (time.monotonic() - self._last_pv_curtail_toggle) < pv_curtail_cooldown:
+            _LOGGER.debug("EM: Peak shaving '%s' blocked by curtail cooldown", option)
+            return False
+
+        if self._dry_run:
+            _LOGGER.info(
+                "EM DRY-RUN: Would set peak shaving -> %s for %s",
+                option,
+                mask_sn(self._sn),
+            )
+            self._last_pv_curtail_toggle = time.monotonic()
+            self._pv_curtailed = option == "stop"
+            self._last_action = f"[dry-run] peak_shaving_{option}"
+            self._notify_sensors()
+            return True
+
+        client: HyxiApiClient = self._coordinator.client
+        try:
+            await client.set_peak_shaving(self._sn, option)
+            self._last_pv_curtail_toggle = time.monotonic()
+            self._pv_curtailed = option == "stop"
+            self._last_action = f"peak_shaving_{option}"
+            _LOGGER.info("EM: Peak shaving -> %s for %s", option, mask_sn(self._sn))
+            self._notify_sensors()
+            return True
+        except HyxiApiClient.ControlError as err:
+            _LOGGER.error("EM: Failed to set peak shaving '%s': %s", option, err)
+            return False
+
+    async def _release_pv_curtailment(self) -> None:
+        """Resume PV production after curtailment by sending peak shaving 'hold'."""
+        if not self._pv_curtailed:
+            return
+        _LOGGER.info("EM: Releasing PV curtailment — resuming production")
+        await self._set_peak_shaving("hold")
+        self._pv_curtailed = False
+
+    def _get_current_power_setting(self, direction: str) -> float:
+        """Get the last-sent power for the given direction.
+
+        Uses internal tracking (set by _set_mode/_adjust_power). Falls back
+        to the number entity if it exists (e.g. three-phase power numbers).
+        """
+        tracked = self._last_sent_power.get(direction, 0)
+        if tracked > 0:
+            return tracked
+        unique_id = f"hyxi_{self._sn}_{direction}_power"
+        entity_id = self._find_entity_id("number", unique_id)
+        if entity_id:
+            return self._get_ha_state_float(entity_id, 0)
+        return 0
+
+    # ── Night consumption estimation ────────────────────────────────────
+
+    def _estimate_night_consumption_wh(self) -> float:
+        """Estimate energy needed to survive the night (Wh)."""
+        avg_load = self._get_param("avg_night_consumption")
+        hours_until_solar = self._hours_until_sunrise() + 1.0
+        night_hours = 11
+        hours_remaining = min(hours_until_solar, night_hours)
+        wh_needed = avg_load * hours_remaining
+        buffer_pct = self._get_param("night_buffer_pct") / 100
+        wh_needed *= 1 + buffer_pct
+        return wh_needed
+
+    def _soc_needed_for_night(self) -> float:
+        """Calculate the SOC percentage needed to survive the night."""
+        wh_needed = self._estimate_night_consumption_wh()
+        capacity = self._get_param("battery_capacity_wh")
+        # Read soc_min from EXISTING protection number entity
+        soc_min = self._get_protection_param("soc_min", 20)
+        if capacity <= 0:
+            capacity = 10000
+        soc_pct_needed = (wh_needed / capacity) * 100
+        return soc_min + soc_pct_needed
+
+    # ── Solar forecast helpers ──────────────────────────────────────────
+
+    def _get_forecast_remaining_wh(self) -> float:
+        """Get remaining solar forecast for today in Wh."""
+        remaining_kwh = self._get_ha_state_float(self._forecast_entity, 0)
+        return remaining_kwh * 1000
+
+    def _solar_will_cover_charge(self, target_soc: float) -> bool:
+        """Check if forecasted solar can charge battery to target SOC."""
+        current_soc = self._get_soc()
+        capacity = self._get_param("battery_capacity_wh")
+        wh_needed = capacity * (target_soc - current_soc) / 100
+        if wh_needed <= 0:
+            return True
+
+        forecast_wh = self._get_forecast_remaining_wh()
+        if forecast_wh > 0:
+            usable_forecast = forecast_wh * 0.6
+            return usable_forecast >= wh_needed
+
+        # No forecast — estimate from current solar and time to sunset
+        solar_now = self._get_solar()
+        hours_to_sunset = self._hours_until_sunset()
+        if hours_to_sunset <= 0 or solar_now <= 100:
+            return False
+
+        avg_night_load = self._get_param("avg_night_consumption")
+        estimated_solar_wh = (solar_now / 2) * hours_to_sunset
+        usable_wh = (estimated_solar_wh - avg_night_load * hours_to_sunset) * 0.8
+        return usable_wh >= wh_needed
+
+    # ── Battery energy calculation ──────────────────────────────────────
+
+    def battery_energy_available_wh(self) -> float:
+        """Calculate available battery energy above soc_min in Wh."""
+        soc = self._get_soc()
+        # Read soc_min from EXISTING protection number entity
+        soc_min = self._get_protection_param("soc_min", 20)
+        capacity = self._get_param("battery_capacity_wh")
+        usable_pct = max(0, soc - soc_min)
+        return capacity * usable_pct / 100
+
+    # ── Main decision engine ────────────────────────────────────────────
+
+    async def _make_decision(self) -> None:
+        """Core decision logic. Called every EM_LOOP_INTERVAL seconds.
+
+        Priority order:
+          1. Safety: SOC below minimum -> emergency charge
+          2. Safety: SOC above maximum -> forced discharge
+          3. Sustained high load -> battery assist or idle
+          4. Night -> self_consume until soc_min, then idle
+          4b. Night preservation -> idle if SOC <= night target
+          5. Solar optimization -> self_consume first, charge on sustained export
+        """
+        # Read soc_min/soc_max from EXISTING protection number entities
+        solar = self._get_solar()
+        s = DecisionState(
+            soc=self._get_soc(),
+            solar=solar,
+            p1=self._get_p1(),
+            home_load=self._get_home_load(),
+            soc_min=self._get_protection_param("soc_min", 20),
+            soc_max=self._get_protection_param("soc_max", 90),
+            max_charge=self._get_param("max_charge_power"),
+            max_discharge=self._get_param("max_discharge_power"),
+            is_night=self._is_night(),
+            solar_producing=solar > 50,
+            night_soc_target=self._soc_needed_for_night(),
+        )
+
+        _LOGGER.debug(
+            "EM TICK: SOC=%.0f%% P1=%.0fW solar=%.0fW load=%.0fW "
+            "night=%s night_target=%.0f%%",
+            s.soc,
+            s.p1,
+            s.solar,
+            s.home_load,
+            s.is_night,
+            s.night_soc_target,
+        )
+
+        # PRIORITY 1 & 2: SOC safety limits
+        if await self._check_soc_limits(s):
+            return
+
+        # PRIORITY 2b: Export limiting
+        if await self._check_export_limit(s):
+            return
+
+        # PRIORITY 3: Sustained high load
+        if await self._check_high_load(s):
+            return
+
+        # PRIORITY 4 & 4b: Night mode
+        if await self._check_night(s):
+            return
+
+        # PRIORITY 5: Solar optimization
+        if await self._check_solar(s):
+            return
+
+        # ── DEFAULT: self_consume as safe fallback ─────────────────────
+        self._set_decision("idle_default")
+        if self._current_mode in ("charge", "discharge"):
+            await self._set_mode("self_consume")
+
+    async def _check_soc_limits(self, s: DecisionState) -> bool:
+        """PRIORITY 1 & 2: SOC safety limits. Returns True if handled."""
+        if s.soc <= s.soc_min:
+            if s.solar_producing:
+                charge_target = min(s.solar - 50, s.max_charge)
+                charge_target = max(charge_target, 300)
+                # Absorb grid export: if P1 negative, increase charge to
+                # capture excess solar instead of wasting it to grid
+                if s.p1 < 0:
+                    charge_target = min(
+                        charge_target + abs(int(s.p1)), int(s.max_charge)
+                    )
+                self._set_decision("emergency_solar_charge")
+                if self._current_mode != "charge":
+                    await self._set_mode("charge", int(charge_target))
+                else:
+                    await self._adjust_power("charge", int(charge_target))
+                return True
+
+            grid_charge_uid = f"hyxi_{self._sn}_em_grid_charge_allowed"
+            grid_entity = self._find_entity_id("switch", grid_charge_uid)
+            if self._get_ha_state_bool(grid_entity):
+                grid_charge_w = min(2000, int(s.max_charge))
+                self._set_decision("grid_charge_emergency")
+                if self._current_mode != "charge":
+                    await self._set_mode("charge", grid_charge_w)
+                else:
+                    await self._adjust_power("charge", grid_charge_w)
+                return True
+            self._set_decision("low_soc_idle")
+            if self._current_mode != "idle":
+                await self._set_mode("idle")
+            return True
+
+        if s.soc > s.soc_max:
+            discharge_w = max(s.p1, 1000)
+            discharge_w = min(discharge_w, s.max_discharge)
+            self._set_decision("forced_discharge_over_max")
+            if self._current_mode != "discharge":
+                await self._set_mode("discharge", int(discharge_w))
+            else:
+                await self._adjust_power("discharge", int(discharge_w))
+            return True
+
+        return False
+
+    async def _check_export_limit(self, s: DecisionState) -> bool:
+        """PRIORITY 2b: Export limiting (single-phase only). Returns True if handled.
+
+        Only applies to single-phase devices with peak shaving support
+        (controlId 1021). Uses battery charge to absorb excess when SOC
+        allows, and PV curtailment (stop/hold) when battery is full.
+        Three-phase devices rely on existing mode controls instead.
+        """
+        if not self._has_peak_shaving():
+            return False
+
+        export_limit_uid = f"hyxi_{self._sn}_em_export_limiting"
+        export_limit_entity = self._find_entity_id("switch", export_limit_uid)
+        if not self._get_ha_state_bool(export_limit_entity, False):
+            if self._pv_curtailed:
+                await self._release_pv_curtailment()
+            return False
+
+        max_export = self._get_param("max_grid_export")
+        if max_export <= 0:
+            if self._pv_curtailed:
+                await self._release_pv_curtailment()
+            return False
+
+        # P1 negative = exporting; check if export exceeds limit
+        if s.p1 < -max_export:
+            if s.soc < s.soc_max:
+                # Battery has room — charge to absorb excess
+                if self._pv_curtailed:
+                    await self._release_pv_curtailment()
+                excess = abs(s.p1) - max_export
+                charge_target = min(excess, s.max_charge)
+                charge_target = max(charge_target, 300)
+                self._set_decision("export_limit_charge")
+                if self._current_mode != "charge":
+                    await self._set_mode("charge", int(charge_target))
+                else:
+                    await self._adjust_power("charge", int(charge_target))
+                return True
+
+            # Battery full — curtail PV via peak shaving stop
+            self._set_decision("export_limit_pv_curtail")
+            if not self._pv_curtailed:
+                await self._set_peak_shaving("stop")
+            return True
+
+        # Export within limit — release curtailment if active
+        if self._pv_curtailed:
+            self._set_decision("export_limit_pv_resume")
+            await self._release_pv_curtailment()
+            return True
+
+        # Were charging due to export limit but export is now within limit
+        if (
+            self._current_mode == "charge"
+            and self._last_decision == "export_limit_charge"
+        ):
+            if s.p1 >= -max_export:
+                self._set_decision("export_limit_ok")
+                await self._set_mode("self_consume")
+                return True
+
+        return False
+
+    async def _check_high_load(self, s: DecisionState) -> bool:
+        """PRIORITY 3: Sustained high load. Returns True if handled."""
+        # Check if high load feature is enabled by the user
+        high_load_assist_uid = f"hyxi_{self._sn}_em_high_load_battery_assist"
+        high_load_entity = self._find_entity_id("switch", high_load_assist_uid)
+        high_load_assist = self._get_ha_state_bool(high_load_entity, False)
+        if not high_load_assist:
+            return False
+
+        high_load_threshold = self._get_param("high_load_threshold")
+
+        if s.home_load > high_load_threshold:
+            high_load_wh = s.max_discharge * 0.5
+            capacity = self._get_param("battery_capacity_wh")
+            soc_cost = (high_load_wh / capacity) * 100 if capacity > 0 else 100
+
+            if (s.soc - soc_cost) > s.night_soc_target:
+                self._set_decision("high_load_battery_assist")
+                if self._current_mode != "self_consume":
+                    await self._set_mode("self_consume")
+            else:
+                self._set_decision("high_load_grid_only")
+                if self._current_mode != "idle":
+                    await self._set_mode("idle")
+            return True
+
+        return False
+
+    async def _check_night(self, s: DecisionState) -> bool:
+        """PRIORITY 4 & 4b: Night mode. Returns True if handled."""
+        # Check if night mode feature is enabled by the user
+        night_mode_uid = f"hyxi_{self._sn}_em_night_mode"
+        night_mode_entity = self._find_entity_id("switch", night_mode_uid)
+        if not self._get_ha_state_bool(night_mode_entity, False):
+            return False
+
+        if not s.solar_producing and s.is_night:
+            if s.soc > s.soc_min:
+                self._set_decision("night_self_consume")
+                if self._current_mode != "self_consume":
+                    await self._set_mode("self_consume")
+            else:
+                self._set_decision("night_reserve_hold")
+                if self._current_mode != "idle":
+                    await self._set_mode("idle")
+            return True
+
+        # Night battery preservation during daytime
+        p1_avg = self.p1_avg
+        if (
+            not s.is_night
+            and s.soc <= s.night_soc_target
+            and s.p1 > 0
+            and p1_avg > 0
+            and not self._solar_will_cover_charge(s.night_soc_target)
+        ):
+            self._set_decision("night_preserve_idle")
+            if self._current_mode != "idle":
+                await self._set_mode("idle")
+            return True
+
+        return False
+
+    async def _check_solar(self, s: DecisionState) -> bool:
+        """PRIORITY 5: Solar optimization. Returns True if handled."""
+        if s.solar_producing and s.soc < s.soc_max:
+            await self._solar_charge_logic(s)
+            return True
+
+        if s.solar_producing and s.soc >= s.soc_max:
+            self._set_decision("solar_battery_full")
+            if self._current_mode != "self_consume":
+                await self._set_mode("self_consume")
+            return True
+
+        return False
+
+    async def _solar_charge_logic(self, s: DecisionState) -> None:
+        """Solar charge entry/exit and power tuning logic."""
+        min_solar_for_charge = self._get_param("min_solar_for_charge")
+        charge_margin = self._get_param("charge_margin")
+        charge_entry_threshold = self._get_param("charge_entry_threshold")
+        charge_reentry_delay = self._get_param("charge_reentry_delay")
+        readings_needed = max(int(charge_reentry_delay / 15 / 3), 2)
+
+        # After a bottomout exit, double the readings needed
+        bottomout_cooldown = self._get_param("bottomout_cooldown")
+        if (time.monotonic() - self._last_bottomout_exit) < bottomout_cooldown:
+            readings_needed = readings_needed * 2
+
+        # Sunset urgency
+        hours_to_sunset = self._hours_until_sunset()
+        sunset_urgent = False
+        if hours_to_sunset < 4 and s.soc < s.night_soc_target:
+            if not self._solar_will_cover_charge(s.night_soc_target):
+                sunset_urgent = True
+                charge_entry_threshold = max(charge_entry_threshold // 2, 100)
+                readings_needed = max(readings_needed // 2, 1)
+                min_solar_for_charge = max(min_solar_for_charge - 300, 200)
+
+        sc = SolarConfig(
+            min_solar_for_charge=min_solar_for_charge,
+            charge_margin=charge_margin,
+            charge_entry_threshold=charge_entry_threshold,
+            readings_needed=readings_needed,
+            sunset_urgent=sunset_urgent,
+        )
+
+        if self._current_mode != "charge":
+            await self._solar_entry_logic(s, sc)
+        else:
+            await self._solar_tune_logic(s, sc)
+
+    async def _solar_entry_logic(
+        self,
+        s: DecisionState,
+        sc: SolarConfig,
+    ) -> None:
+        """Handle charge entry decision when not currently charging."""
+        if s.solar < sc.min_solar_for_charge:
+            self._set_decision("solar_self_consume")
+            if self._current_mode not in ("self_consume", "idle"):
+                await self._set_mode("self_consume")
+            self._charge_entry_export_count = 0
+
+        elif s.p1 < -sc.charge_entry_threshold:
+            self._charge_entry_export_count += 1
+            if (
+                self._charge_entry_export_count >= sc.readings_needed
+                and s.solar >= sc.min_solar_for_charge
+            ):
+                charge_target = min(abs(s.p1) - sc.charge_margin - 100, s.solar - 500)
+                charge_target = min(charge_target, s.max_charge)
+                charge_target = max(charge_target, 300)
+                decision = "pre_night_charge" if sc.sunset_urgent else "solar_charge"
+                self._set_decision(decision)
+                if await self._set_mode("charge", int(charge_target)):
+                    self._charge_entry_export_count = 0
+            else:
+                self._set_decision("solar_export_waiting")
+                if self._current_mode not in ("self_consume", "idle"):
+                    await self._set_mode("self_consume")
+        else:
+            self._charge_entry_export_count = 0
+            self._set_decision("solar_self_consume")
+            if self._current_mode not in ("self_consume", "idle"):
+                await self._set_mode("self_consume")
+
+    async def _solar_tune_logic(
+        self,
+        s: DecisionState,
+        sc: SolarConfig,
+    ) -> None:
+        """Fine-tune charge power when already in charge mode."""
+        current_charge = self._get_current_power_setting("charge")
+        solar_cap = max(s.solar - sc.charge_margin, 100)
+
+        if s.solar < sc.min_solar_for_charge - 150:
+            self._set_decision("solar_self_consume")
+            self._last_charge_exit = time.monotonic()
+            self._charge_entry_export_count = 0
+            self._charge_bottomout_count = 0
+            await self._set_mode("self_consume")
+
+        elif s.p1 > sc.charge_margin:
+            await self._solar_reduce_charge(
+                s.p1, current_charge, solar_cap, sc.charge_margin
+            )
+
+        elif s.p1 < -(sc.charge_margin + 100):
+            # Exporting too much — increase charge
+            # Decrement bottomout counter (don't fully reset — volatile P1
+            # can briefly dip negative between import spikes)
+            self._charge_bottomout_count = max(0, self._charge_bottomout_count - 1)
+            excess_export = abs(s.p1) - sc.charge_margin
+            charge_target = current_charge + excess_export
+            charge_target = min(charge_target, s.max_charge)
+            charge_target = min(charge_target, solar_cap)
+            self._set_decision("solar_charge")
+            await self._adjust_power("charge", int(charge_target))
+        else:
+            # P1 within target range — balanced
+            self._charge_bottomout_count = max(0, self._charge_bottomout_count - 1)
+            self._set_decision("solar_charge")
+
+    async def _solar_reduce_charge(
+        self,
+        p1,
+        current_charge,
+        solar_cap,
+        charge_margin,
+    ) -> None:
+        """Reduce charge power when importing from grid.
+
+        Uses dampened reduction: max 50% cut per tick to avoid volatile P1
+        spikes crashing charge power from high values to 100W in one step.
+        """
+        desired_reduction = p1 + charge_margin
+        max_step = max(current_charge * 0.5, 200)
+        actual_reduction = min(desired_reduction, max_step)
+        charge_target = current_charge - actual_reduction
+        charge_target = min(charge_target, solar_cap)
+        charge_target = max(charge_target, 100)
+
+        if charge_target <= 100:
+            self._charge_bottomout_count += 1
+            if self._charge_bottomout_count >= 5:
+                self._set_decision("solar_self_consume")
+                self._last_charge_exit = time.monotonic()
+                self._last_bottomout_exit = time.monotonic()
+                self._charge_entry_export_count = 0
+                self._charge_bottomout_count = 0
+                await self._set_mode("self_consume")
+            else:
+                self._set_decision("solar_charge_reduced")
+                await self._adjust_power("charge", 100)
+        else:
+            self._charge_bottomout_count = 0
+            self._set_decision("solar_charge")
+            await self._adjust_power("charge", int(charge_target))
+
+    def _set_decision(self, decision: str) -> None:
+        """Update the current decision label."""
+        self._last_decision = decision
+        self._notify_sensors()
+
+    # ── Callbacks ───────────────────────────────────────────────────────
+
+    async def _loop_tick(self, now) -> None:
+        """15-second timer callback."""
+        if not self._enabled:
+            return
+
+        # Staleness guard: auto-reload integration if data hasn't refreshed
+        from homeassistant.util import dt as dt_util
+
+        last_success = self._coordinator.hyxi_metadata.get("last_success")
+        if last_success is not None:
+            stale_seconds = (dt_util.utcnow() - last_success).total_seconds()
+            if stale_seconds > 600:  # 10 minutes
+                _LOGGER.warning(
+                    "EM: Coordinator data stale (%.0f min) — reloading integration",
+                    stale_seconds / 60,
+                )
+                self._hass.components.persistent_notification.async_create(
+                    f"Energy Manager detected stale data ({stale_seconds / 60:.0f} min). "
+                    "Auto-reloading integration to restore updates.",
+                    title="HYXI Cloud: Stale Data",
+                    notification_id="hyxi_stale_data",
+                )
+                await self._hass.config_entries.async_reload(
+                    self._coordinator.entry.entry_id
+                )
+                return
+
+        # Check em_enabled switch — force self_consume on disable
+        em_enabled_uid = f"hyxi_{self._sn}_em_enabled"
+        em_entity = self._find_entity_id("switch", em_enabled_uid)
+        if em_entity and not self._get_ha_state_bool(em_entity, True):
+            if self._current_mode in ("charge", "discharge"):
+                _LOGGER.info(
+                    "EM: Disabled — forcing self_consume from %s for %s",
+                    self._current_mode,
+                    mask_sn(self._sn),
+                )
+                try:
+                    await self._set_mode("self_consume")
+                except OSError, ValueError, TypeError, HyxiApiClient.ControlError:
+                    _LOGGER.debug("EM: Failed to force self_consume on disable")
+                self._set_decision("disabled")
+            return
+
+        try:
+            await self._make_decision()
+        except OSError, ValueError, TypeError, HyxiApiClient.ControlError:
+            _LOGGER.exception("EM: Decision loop error")
+            self._set_decision("error")
+            # Safe fallback
+            try:
+                await self._set_mode("self_consume")
+            except OSError, ValueError, TypeError, HyxiApiClient.ControlError:
+                _LOGGER.debug("EM: Fallback self_consume also failed")
+
+    @callback
+    def _on_p1_change(self, event) -> None:
+        """Handle P1 state changes — update rolling average and high-load fast-path."""
+        new_state = event.data.get("new_state")
+        if new_state is None or new_state.state in ("unknown", "unavailable"):
+            return
+
+        try:
+            value = float(new_state.state)
+        except ValueError, TypeError:
+            return
+
+        now = time.monotonic()
+        self._p1_buffer.append((now, value))
+
+        # Trim buffer to configurable window
+        window = self._get_param("p1_smoothing_period") or _P1_SMOOTHING_DEFAULT
+        cutoff = now - window
+        while self._p1_buffer and self._p1_buffer[0][0] < cutoff:
+            self._p1_buffer.popleft()
+
+        # High-load fast-path: if home_load exceeds threshold, run decision immediately
+        if not self._enabled:
+            return
+
+        home_load = self._get_home_load()
+        threshold = self._get_param("high_load_threshold")
+        if home_load > threshold:
+            self._hass.async_create_task(self._make_decision())
+
+    @callback
+    def _on_soc_change(self, event) -> None:
+        """Handle SOC changes — low-SOC fast-path."""
+        if not self._enabled:
+            return
+
+        new_state = event.data.get("new_state")
+        if new_state is None or new_state.state in ("unknown", "unavailable"):
+            return
+
+        try:
+            soc = float(new_state.state)
+        except ValueError, TypeError:
+            return
+
+        soc_min = self._get_protection_param("soc_min", 20)
+        if soc < soc_min:
+            self._hass.async_create_task(self._make_decision())
+
+    async def _update_night_estimate(self, now) -> None:
+        """Hourly night consumption update — EMA from P1 readings at night."""
+        if not self._enabled:
+            return
+
+        from datetime import datetime as dt
+
+        hour = dt.now().hour
+        if 21 <= hour or hour < 6:
+            current_p1 = self._get_p1()
+            if current_p1 > 0:
+                prev = self._get_param("avg_night_consumption")
+                new_avg = prev * 0.9 + current_p1 * 0.1
+                _LOGGER.info(
+                    "EM: Night consumption estimate: %.0fW (sample: %.0fW)",
+                    new_avg,
+                    current_p1,
+                )

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -16,5 +16,5 @@
     "aiohttp>=3.13.4",
     "hyxi-cloud-api>=1.2.6"
   ],
-  "version": "1.5.0"
+  "version": "1.6.0-beta1"
 }

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.6"
+    "hyxi-cloud-api>=1.2.7"
   ],
-  "version": "1.6.0-beta1"
+  "version": "1.5.0"
 }

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -1,6 +1,7 @@
 """Number platform for HYXI Cloud device control power settings."""
 
 import logging
+from typing import NamedTuple
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -13,7 +14,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from hyxi_cloud_api import HyxiApiClient
 
 from .const import (
+    CONF_EM_ENABLED,
+    CONF_EM_INVERTER_SN,
     DOMAIN,
+    EM_DEFAULTS,
     MANUFACTURER,
     detect_phase_type,
     get_raw_device_code,
@@ -65,6 +69,43 @@ PROTECTION_NUMBER_DEFS: list[dict[str, str | int]] = [
 ]
 
 
+class EMNumberDef(NamedTuple):
+    """Definition for an Energy Manager number entity."""
+
+    key: str
+    unit: str
+    min_val: float
+    max_val: float
+    step: float
+    icon: str
+
+
+# EM-only: created only when Energy Manager is enabled in options
+EM_NUMBER_DEFS: list[EMNumberDef] = [
+    EMNumberDef("high_load_threshold", "W", 1000, 20000, 500, "mdi:flash-alert"),
+    EMNumberDef("max_charge_power", "W", 500, 15000, 100, "mdi:lightning-bolt"),
+    EMNumberDef(
+        "max_discharge_power", "W", 500, 15000, 100, "mdi:lightning-bolt-outline"
+    ),
+    EMNumberDef(
+        "min_solar_for_charge", "W", 200, 3000, 100, "mdi:solar-power-variant-outline"
+    ),
+    EMNumberDef("mode_switch_cooldown", "s", 10, 300, 5, "mdi:timer-outline"),
+    EMNumberDef("power_change_threshold", "W", 10, 500, 10, "mdi:delta"),
+    EMNumberDef("power_adjust_cooldown", "s", 5, 120, 5, "mdi:timer-sand"),
+    EMNumberDef("night_buffer_pct", "%", 0, 20, 1, "mdi:shield-half-full"),
+    EMNumberDef("avg_night_consumption", "W", 100, 2000, 50, "mdi:weather-night"),
+    EMNumberDef("charge_margin", "W", 0, 500, 25, "mdi:margin"),
+    EMNumberDef(
+        "charge_entry_threshold", "W", 100, 2000, 50, "mdi:solar-power-variant-outline"
+    ),
+    EMNumberDef("charge_reentry_delay", "s", 30, 600, 15, "mdi:timer-lock"),
+    EMNumberDef("bottomout_cooldown", "s", 60, 900, 30, "mdi:timer-alert"),
+    EMNumberDef("p1_smoothing_period", "s", 1, 300, 1, "mdi:chart-timeline-variant"),
+    EMNumberDef("max_grid_export", "W", 0, 10000, 100, "mdi:transmission-tower-export"),
+]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -104,6 +145,17 @@ async def async_setup_entry(
             # Microinverter power limit (controlId 3012)
             if is_battery_control_enabled(entry, coordinator):
                 entities.append(HyxiMicroPowerLimit(coordinator, sn, dev_data))
+
+    # EM-only numbers — only when Energy Manager is enabled for this inverter
+    em_sn = entry.options.get(CONF_EM_INVERTER_SN)
+    if entry.options.get(CONF_EM_ENABLED) and em_sn and em_sn in coordinator.data:
+        em_dev_data = coordinator.data.get(em_sn, {})
+        em_is_single_phase = detect_phase_type(em_dev_data) == "single_phase"
+        for numdef in EM_NUMBER_DEFS:
+            # max_grid_export only relevant for single-phase export limiting
+            if numdef.key == "max_grid_export" and not em_is_single_phase:
+                continue
+            entities.append(EMParameterNumber(coordinator, em_sn, numdef))
 
     if entities:
         async_add_entities(entities)
@@ -288,3 +340,50 @@ class HyxiProtectionNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
             )
         ) is not None:
             self.hass.async_create_task(controller.async_evaluate())
+
+
+class EMParameterNumber(NumberEntity, RestoreEntity):
+    """Number entity for an Energy Manager parameter.
+
+    Stores a tunable value locally (RestoreEntity). The engine reads it
+    each tick via _get_param().
+    """
+
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator,
+        sn: str,
+        numdef: EMNumberDef,
+    ) -> None:
+        """Initialize the EM parameter number entity."""
+        self._sn = sn
+        self._attr_unique_id = f"hyxi_{sn}_em_{numdef.key}"
+        self._attr_translation_key = f"em_{numdef.key}"
+        self._attr_native_unit_of_measurement = numdef.unit
+        self._attr_native_min_value = numdef.min_val
+        self._attr_native_max_value = numdef.max_val
+        self._attr_native_step = numdef.step
+        self._attr_icon = numdef.icon
+
+        self._attr_native_value = float(EM_DEFAULTS.get(numdef.key, 0))
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, f"{sn}_energy_manager")},
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known value on startup."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            try:
+                self._attr_native_value = float(last_state.state)
+            except ValueError, TypeError:
+                pass
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the parameter value."""
+        self._attr_native_value = value
+        self.async_write_ha_state()

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -15,6 +15,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -917,7 +918,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # 4. Energy Manager sensors (EM-only)
     em_sn = entry.options.get(CONF_EM_INVERTER_SN)
     if entry.options.get(CONF_EM_ENABLED) and em_sn and em_sn in coordinator.data:
-        em_device_info = {"identifiers": {(DOMAIN, f"{em_sn}_energy_manager")}}
+        em_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{em_sn}_energy_manager")},
+            name="Energy Manager",
+            manufacturer=MANUFACTURER,
+            model="Energy Manager",
+            via_device=(DOMAIN, em_sn),
+        )
         entities.append(
             EMSensor(
                 coordinator, em_sn, EMSensorDef("current_decision", em_device_info)
@@ -1384,7 +1391,7 @@ class EMSensorDef:
     """Definition for an EM sensor entity."""
 
     key: str
-    device_info: dict = field(default_factory=dict)
+    device_info: DeviceInfo
     unit: str | None = None
     device_class: SensorDeviceClass | None = None
     state_class: SensorStateClass | None = None

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -19,6 +20,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    CONF_EM_ENABLED,
+    CONF_EM_INVERTER_SN,
     DOMAIN,
     MANUFACTURER,
     detect_phase_type,
@@ -911,6 +914,75 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 continue
             entities.append(HyxiLastSentModeSensor(coordinator, sn))
 
+    # 4. Energy Manager sensors (EM-only)
+    em_sn = entry.options.get(CONF_EM_INVERTER_SN)
+    if entry.options.get(CONF_EM_ENABLED) and em_sn and em_sn in coordinator.data:
+        em_device_info = {"identifiers": {(DOMAIN, f"{em_sn}_energy_manager")}}
+        entities.append(
+            EMSensor(
+                coordinator, em_sn, EMSensorDef("current_decision", em_device_info)
+            )
+        )
+        entities.append(
+            EMSensor(coordinator, em_sn, EMSensorDef("last_action", em_device_info))
+        )
+        entities.append(
+            EMSensor(
+                coordinator,
+                em_sn,
+                EMSensorDef("status", em_device_info, icon="mdi:state-machine"),
+            )
+        )
+        entities.append(
+            EMSensor(
+                coordinator,
+                em_sn,
+                EMSensorDef(
+                    "battery_energy_available",
+                    em_device_info,
+                    unit="Wh",
+                    device_class=SensorDeviceClass.ENERGY,
+                ),
+            )
+        )
+        entities.append(
+            EMSensor(
+                coordinator,
+                em_sn,
+                EMSensorDef(
+                    "hours_until_sunrise",
+                    em_device_info,
+                    unit="h",
+                    icon="mdi:weather-sunset-up",
+                ),
+            )
+        )
+        entities.append(
+            EMSensor(
+                coordinator,
+                em_sn,
+                EMSensorDef(
+                    "hours_until_sunset",
+                    em_device_info,
+                    unit="h",
+                    icon="mdi:weather-sunset-down",
+                ),
+            )
+        )
+        entities.append(
+            EMSensor(
+                coordinator,
+                em_sn,
+                EMSensorDef(
+                    "p1_average",
+                    em_device_info,
+                    unit="W",
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+            )
+        )
+
     # FINAL REGISTRATION
     if entities:
         async_add_entities(entities)
@@ -1305,3 +1377,89 @@ class HyxiLastSentModeSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
 def _get_protection_controller(coordinator, sn: str):
     """Return the battery protection controller for a device."""
     return getattr(coordinator, "protection_controllers", {}).get(sn)
+
+
+@dataclass
+class EMSensorDef:
+    """Definition for an EM sensor entity."""
+
+    key: str
+    device_info: dict = field(default_factory=dict)
+    unit: str | None = None
+    device_class: SensorDeviceClass | None = None
+    state_class: SensorStateClass | None = None
+    icon: str | None = None
+
+
+class EMSensor(SensorEntity):
+    """Sensor entity backed by the Energy Manager engine.
+
+    Updates are pushed by the engine via a registered callback, not by the
+    coordinator poll cycle.
+    """
+
+    _attr_has_entity_name = True
+
+    _VALUE_GETTERS: ClassVar[dict[str, str]] = {
+        "current_decision": "decision",
+        "last_action": "last_action",
+        "status": "status",
+        "battery_energy_available": "battery_energy_available_wh",
+        "hours_until_sunrise": "_hours_until_sunrise",
+        "hours_until_sunset": "_hours_until_sunset",
+        "p1_average": "p1_avg",
+    }
+
+    def __init__(
+        self,
+        coordinator,
+        sn: str,
+        sensor_def: EMSensorDef,
+    ) -> None:
+        """Initialize the EM sensor."""
+        self._coordinator = coordinator
+        self._sn = sn
+        self._key = sensor_def.key
+        self._attr_unique_id = f"hyxi_{sn}_em_{sensor_def.key}"
+        self._attr_translation_key = f"em_{sensor_def.key}"
+        self._attr_device_info = sensor_def.device_info
+        self._attr_native_unit_of_measurement = sensor_def.unit
+        self._attr_device_class = sensor_def.device_class
+        self._attr_state_class = sensor_def.state_class
+        if sensor_def.icon:
+            self._attr_icon = sensor_def.icon
+
+    async def async_added_to_hass(self) -> None:
+        """Register for engine updates."""
+        engine = self._coordinator.engine
+        if engine:
+            engine.register_update_callback(self._engine_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister from engine updates."""
+        engine = self._coordinator.engine
+        if engine:
+            engine.unregister_update_callback(self._engine_updated)
+
+    @callback
+    def _engine_updated(self) -> None:
+        """Handle engine state change."""
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self):
+        """Return the current value from the engine."""
+        engine = self._coordinator.engine
+        if not engine:
+            return None
+        getter_name = self._VALUE_GETTERS.get(self._key)
+        if not getter_name:
+            return None
+        attr = getattr(engine, getter_name, None)
+        if callable(attr):
+            value = attr()
+        else:
+            value = attr
+        if isinstance(value, float):
+            return round(value, 1)
+        return value

--- a/custom_components/hyxi_cloud/strings.json
+++ b/custom_components/hyxi_cloud/strings.json
@@ -38,7 +38,22 @@
         "data": {
           "update_interval": "Polling Interval (1-60 Minutes, Default: 5)",
           "back_discovery": "Enable discovery via alarms (Advanced)",
-          "enable_battery_control": "Enable Device Control & Protection"
+          "enable_battery_control": "Enable Device Control & Protection",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -61,6 +76,12 @@
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -423,6 +444,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -446,6 +488,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -454,6 +541,21 @@
       },
       "micro_power": {
         "name": "Power"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -1,14 +1,22 @@
 """Switch platform for HYXI Cloud device control."""
 
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
+from typing import ClassVar
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from hyxi_cloud_api import VPP_ACTIVE_MODES, HyxiApiClient
 
 from .const import (
+    CONF_EM_ENABLED,
+    CONF_EM_INVERTER_SN,
     DOMAIN,
     detect_phase_type,
     get_raw_device_code,
@@ -54,6 +62,46 @@ async def async_setup_entry(
         elif device_type == "micro_inverter":
             if is_battery_control_enabled(entry, coordinator):
                 entities.append(HyxiMicroPowerSwitch(coordinator, sn, dev_data))
+
+    # EM-only switches — only when EM is enabled for this inverter
+    em_sn = entry.options.get(CONF_EM_INVERTER_SN)
+    if entry.options.get(CONF_EM_ENABLED) and em_sn and em_sn in coordinator.data:
+        # Grid charge toggle on inverter device
+        entities.append(
+            EMToggleSwitch(
+                coordinator, em_sn, EMToggleDef("grid_charge_allowed"), em_device=False
+            )
+        )
+        # EM engine toggles on EM virtual device
+        entities.append(
+            EMToggleSwitch(coordinator, em_sn, EMToggleDef("enabled"), em_device=True)
+        )
+        entities.append(
+            EMToggleSwitch(
+                coordinator, em_sn, EMToggleDef("night_mode"), em_device=True
+            )
+        )
+        entities.append(
+            EMToggleSwitch(
+                coordinator,
+                em_sn,
+                EMToggleDef("high_load_battery_assist"),
+                em_device=True,
+            )
+        )
+
+        # Export limiting — single-phase only (uses peak shaving controlId 1021)
+        em_dev_data = coordinator.data.get(em_sn, {})
+        em_phase = detect_phase_type(em_dev_data)
+        if em_phase == "single_phase":
+            entities.append(
+                EMToggleSwitch(
+                    coordinator,
+                    em_sn,
+                    EMToggleDef("export_limiting"),
+                    em_device=True,
+                )
+            )
 
     if entities:
         async_add_entities(entities)
@@ -154,3 +202,70 @@ class HyxiMicroPowerSwitch(HyxiEntity, SwitchEntity):
                 "Failed to power off microinverter %s: %s", mask_sn(self._sn), err
             )
             raise
+
+
+@dataclass
+class EMToggleDef:
+    """Definition for an EM toggle switch."""
+
+    key: str
+    default_on: bool = False
+
+
+class EMToggleSwitch(SwitchEntity, RestoreEntity):
+    """Toggle switch for Energy Manager parameters.
+
+    Stores state locally (RestoreEntity). The engine reads it each tick.
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_is_on: bool | None = None
+
+    _ICONS: ClassVar[dict[str, str]] = {
+        "grid_charge_allowed": "mdi:transmission-tower-import",
+        "enabled": "mdi:robot",
+        "night_mode": "mdi:weather-night",
+        "high_load_battery_assist": "mdi:flash-alert-outline",
+        "export_limiting": "mdi:transmission-tower-off",
+    }
+
+    def __init__(
+        self,
+        coordinator,
+        sn: str,
+        toggle_def: EMToggleDef,
+        em_device: bool = False,
+    ) -> None:
+        """Initialize the EM toggle switch."""
+        self._sn = sn
+        key = toggle_def.key
+        self._attr_unique_id = f"hyxi_{sn}_em_{key}"
+        self._attr_translation_key = f"em_{key}"
+        self._attr_icon = self._ICONS.get(key, "mdi:toggle-switch")
+        self._attr_is_on = toggle_def.default_on
+
+        if em_device:
+            self._attr_device_info = {
+                "identifiers": {(DOMAIN, f"{sn}_energy_manager")},
+            }
+        else:
+            self._attr_device_info = {
+                "identifiers": {(DOMAIN, sn)},
+            }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known value on startup."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == "on"
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn on."""
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off."""
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/custom_components/hyxi_cloud/translations/af.json
+++ b/custom_components/hyxi_cloud/translations/af.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Opvragsinterval (1-60 minute, verstek: 5)",
           "back_discovery": "Aktiveer ontdekking via alarms (Gevorderd)",
-          "enable_battery_control": "Aktiveer toestelbeheer en -beskerming"
+          "enable_battery_control": "Aktiveer toestelbeheer en -beskerming",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Probleem"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Krag"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/cs.json
+++ b/custom_components/hyxi_cloud/translations/cs.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Interval dotazování (1-60 minut, výchozí: 5)",
           "back_discovery": "Povolit vyhledávání prostřednictvím alarmů (pro pokročilé)",
-          "enable_battery_control": "Aktivovat ovládání a ochranu zařízení"
+          "enable_battery_control": "Aktivovat ovládání a ochranu zařízení",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problém"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Napájení"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/da.json
+++ b/custom_components/hyxi_cloud/translations/da.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Opdateringsinterval (1-60 minutter, standard: 5)",
           "back_discovery": "Aktiver opdagelse via alarmer (avanceret)",
-          "enable_battery_control": "Aktiver enhedskontrol og -beskyttelse"
+          "enable_battery_control": "Aktiver enhedskontrol og -beskyttelse",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problem"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Strøm"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/de.json
+++ b/custom_components/hyxi_cloud/translations/de.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Abfrageintervall (1-60 Minuten, Standard: 5)",
           "back_discovery": "Discovery über Alarme aktivieren (Erweitert)",
-          "enable_battery_control": "Gerätesteuerung und -schutz aktivieren"
+          "enable_battery_control": "Gerätesteuerung und -schutz aktivieren",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -60,6 +75,12 @@
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Strom"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/en.json
+++ b/custom_components/hyxi_cloud/translations/en.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Polling Interval (1-60 Minutes, Default: 5)",
           "back_discovery": "Enable discovery via alarms (Advanced)",
-          "enable_battery_control": "Enable Device Control & Protection"
+          "enable_battery_control": "Enable Device Control & Protection",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -60,6 +75,12 @@
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -422,6 +443,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -445,6 +487,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -453,6 +540,21 @@
       },
       "micro_power": {
         "name": "Power"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/es.json
+++ b/custom_components/hyxi_cloud/translations/es.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Intervalo de actualización (1-60 minutos, por defecto: 5)",
           "back_discovery": "Habilitar descubrimiento mediante alarmas (Avanzado)",
-          "enable_battery_control": "Activar control y protección del dispositivo"
+          "enable_battery_control": "Activar control y protección del dispositivo",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problema"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Alimentación"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/fi.json
+++ b/custom_components/hyxi_cloud/translations/fi.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Päivitysväli (1-60 minuuttia, oletus: 5)",
           "back_discovery": "Ota löytäminen käyttöön hällytysten kautta (edistynyt)",
-          "enable_battery_control": "Ota laitteen ohjaus ja suojaus käyttöön"
+          "enable_battery_control": "Ota laitteen ohjaus ja suojaus käyttöön",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Ongelma"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Virta"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/fr.json
+++ b/custom_components/hyxi_cloud/translations/fr.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Intervalle de mise à jour (1-60 minutes, Défaut : 5)",
           "back_discovery": "Activer la découverte via les alarmes (Avancé)",
-          "enable_battery_control": "Activer le contrôle et la protection de l'appareil"
+          "enable_battery_control": "Activer le contrôle et la protection de l'appareil",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problème"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Alimentation"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/hu.json
+++ b/custom_components/hyxi_cloud/translations/hu.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Lekérdezési időköz (1-60 perc, alapértelmezett: 5)",
           "back_discovery": "Eszközfelderítés engedélyezése riasztásokon keresztül (haladó)",
-          "enable_battery_control": "Eszközvezérlés és -védelem engedélyezése"
+          "enable_battery_control": "Eszközvezérlés és -védelem engedélyezése",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Probléma"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Tápellátás"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/it.json
+++ b/custom_components/hyxi_cloud/translations/it.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Intervallo di aggiornamento (1-60 Minuti, Predefinito: 5)",
           "back_discovery": "Abilita il rilevamento tramite allarmi (Avanzato)",
-          "enable_battery_control": "Abilita controllo e protezione dispositivo"
+          "enable_battery_control": "Abilita controllo e protezione dispositivo",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problema"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Alimentazione"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/ja.json
+++ b/custom_components/hyxi_cloud/translations/ja.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "ポーリング間隔 (1-60分, デフォルト: 5)",
           "back_discovery": "アラーム経由の検出を有効にする (高度)",
-          "enable_battery_control": "デバイス制御と保護を有効にする"
+          "enable_battery_control": "デバイス制御と保護を有効にする",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "異常あり"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "電源"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/nb.json
+++ b/custom_components/hyxi_cloud/translations/nb.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Oppdateringsintervall (1-60 minutter, standard: 5)",
           "back_discovery": "Aktiver oppdaging via alarmer (avansert)",
-          "enable_battery_control": "Aktiver enhetskontroll og -beskyttelse"
+          "enable_battery_control": "Aktiver enhetskontroll og -beskyttelse",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problem"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Strøm"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/nl.json
+++ b/custom_components/hyxi_cloud/translations/nl.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Update-interval (1-60 minuten, Standaard: 5)",
           "back_discovery": "Ontdekking via alarmen inschakelen (Geavanceerd)",
-          "enable_battery_control": "Apparaatcontrole en -bescherming inschakelen"
+          "enable_battery_control": "Apparaatcontrole en -bescherming inschakelen",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Probleem"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Voeding"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/pl.json
+++ b/custom_components/hyxi_cloud/translations/pl.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Interwał odpytywania (1-60 minut, domyślnie: 5)",
           "back_discovery": "Włącz wykrywanie przez alarmy (zaawansowane)",
-          "enable_battery_control": "Włącz kontrolę i ochronę urządzenia"
+          "enable_battery_control": "Włącz kontrolę i ochronę urządzenia",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problem"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Zasilanie"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/pt-BR.json
+++ b/custom_components/hyxi_cloud/translations/pt-BR.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Intervalo de Atualização (1-60 minutos, padrão: 5)",
           "back_discovery": "Habilitar descoberta via alarmes (Avançado)",
-          "enable_battery_control": "Ativar controle e proteção do dispositivo"
+          "enable_battery_control": "Ativar controle e proteção do dispositivo",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Ativo"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Energia"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/pt.json
+++ b/custom_components/hyxi_cloud/translations/pt.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Intervalo de Atualização (1-60 minutos, padrão: 5)",
           "back_discovery": "Habilitar descoberta via alarmes (Avançado)",
-          "enable_battery_control": "Ativar controle e proteção do dispositivo"
+          "enable_battery_control": "Ativar controle e proteção do dispositivo",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Ativo"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Energia"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/ru.json
+++ b/custom_components/hyxi_cloud/translations/ru.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Интервал обновления (1-60 минут, по умолчанию: 5)",
           "back_discovery": "Включить обнаружение через аварийные сигналы (расширенный режим)",
-          "enable_battery_control": "Включить управление и защиту устройства"
+          "enable_battery_control": "Включить управление и защиту устройства",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Проблема"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Питание"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/sv.json
+++ b/custom_components/hyxi_cloud/translations/sv.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Uppdateringsintervall (1-60 minuter, standard: 5)",
           "back_discovery": "Aktivera upptäckt via larm (Avancerat)",
-          "enable_battery_control": "Aktivera enhetskontroll och -skydd"
+          "enable_battery_control": "Aktivera enhetskontroll och -skydd",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Problem"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Ström"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/tr.json
+++ b/custom_components/hyxi_cloud/translations/tr.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "Sorgulama Aralığı (1-60 Dakika, Varsayılan: 5)",
           "back_discovery": "Alarmlar aracılığıyla keşfi etkinleştir (Gelişmiş)",
-          "enable_battery_control": "Cihaz kontrolünü ve korumasını etkinleştir"
+          "enable_battery_control": "Cihaz kontrolünü ve korumasını etkinleştir",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "Sorun"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "Güç"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/custom_components/hyxi_cloud/translations/zh-Hans.json
+++ b/custom_components/hyxi_cloud/translations/zh-Hans.json
@@ -37,7 +37,22 @@
         "data": {
           "update_interval": "轮询间隔 (1-60 分钟, 默认: 5)",
           "back_discovery": "启用通过报警发现设备 (高级)",
-          "enable_battery_control": "启用设备控制与保护"
+          "enable_battery_control": "启用设备控制与保护",
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+        }
+      },
+      "energy_manager": {
+        "title": "Energy Manager",
+        "description": "Configure the Energy Manager to optimize battery usage based on solar production, grid meter, and forecast data.",
+        "data": {
+          "em_p1_entity": "P1 Smart Meter (power sensor)",
+          "em_forecast_entity": "Solar Forecast Remaining Today (optional)",
+          "em_forecast_power_entity": "Solar Forecast Current Power (optional)",
+          "em_inverter_sn": "Inverter to Control",
+          "em_battery_capacity_override": "Override Battery Capacity",
+          "em_battery_capacity_wh": "Battery Capacity (Wh)",
+          "em_loop_interval": "Decision Loop Interval (seconds)",
+          "em_dry_run": "Dry-Run Mode (no API calls)"
         }
       }
     }
@@ -54,12 +69,18 @@
           "on": "有故障"
         }
       },
-      "vpp_active": {
+"vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",
           "on": "VPP Dispatch Active"
         }
+      },
+      "em_night_mode_active": {
+        "name": "Night Mode"
+      },
+      "em_high_load_detected": {
+        "name": "High Load Detected"
       }
     },
     "sensor": {
@@ -421,6 +442,27 @@
       },
       "last_sent_mode": {
         "name": "Last Sent Mode"
+      },
+      "em_current_decision": {
+        "name": "EM Decision"
+      },
+      "em_last_action": {
+        "name": "EM Last Action"
+      },
+      "em_battery_energy_available": {
+        "name": "Battery Energy Available"
+      },
+      "em_hours_until_sunrise": {
+        "name": "Hours Until Sunrise"
+      },
+      "em_hours_until_sunset": {
+        "name": "Hours Until Sunset"
+      },
+      "em_p1_average": {
+        "name": "P1 Average Power"
+      },
+      "em_status": {
+        "name": "EM Status"
       }
     },
     "number": {
@@ -444,6 +486,51 @@
       },
       "soc_max_hysteresis_pct": {
         "name": "SOC Max Hysteresis"
+      },
+      "em_high_load_threshold": {
+        "name": "High Load Threshold"
+      },
+      "em_max_charge_power": {
+        "name": "Max Charge Power"
+      },
+      "em_max_discharge_power": {
+        "name": "Max Discharge Power"
+      },
+      "em_min_solar_for_charge": {
+        "name": "Min Solar for Charge"
+      },
+      "em_mode_switch_cooldown": {
+        "name": "Mode Switch Cooldown"
+      },
+      "em_power_change_threshold": {
+        "name": "Power Change Threshold"
+      },
+      "em_power_adjust_cooldown": {
+        "name": "Power Adjust Cooldown"
+      },
+      "em_night_buffer_pct": {
+        "name": "Night Buffer"
+      },
+      "em_avg_night_consumption": {
+        "name": "Avg Night Consumption"
+      },
+      "em_charge_margin": {
+        "name": "Charge Margin"
+      },
+      "em_charge_entry_threshold": {
+        "name": "Charge Entry Threshold"
+      },
+      "em_charge_reentry_delay": {
+        "name": "Charge Re-entry Delay"
+      },
+      "em_bottomout_cooldown": {
+        "name": "Bottom-out Cooldown"
+      },
+      "em_max_grid_export": {
+        "name": "Max Grid Export"
+      },
+      "em_p1_smoothing_period": {
+        "name": "P1 Smoothing Period"
       }
     },
     "switch": {
@@ -452,6 +539,21 @@
       },
       "micro_power": {
         "name": "电源"
+      },
+      "em_grid_charge_allowed": {
+        "name": "Grid Charge Allowed"
+      },
+      "em_enabled": {
+        "name": "Energy Manager"
+      },
+      "em_high_load_battery_assist": {
+        "name": "High Load Battery Assist"
+      },
+      "em_night_mode": {
+        "name": "Night Mode"
+      },
+      "em_export_limiting": {
+        "name": "Export Limiting"
       }
     },
     "button": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.2.6"
+    "hyxi-cloud-api>=1.2.7"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.6
+hyxi-cloud-api>=1.2.7
 
 # Development/Linting tools
 ruff>=0.15.14

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.9
-hyxi-cloud-api>=1.2.6
+hyxi-cloud-api>=1.2.7
 pytest-homeassistant-custom-component>=0.13.333

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -350,6 +350,8 @@ async def test_options_flow_show_form_default_fallback(mock_ha_environment):
     config_entry.options = {}  # Empty options to trigger default fallback
 
     options_flow = config_flow_mod.HyxiOptionsFlowHandler(config_entry)
+    options_flow.hass = MagicMock()
+    options_flow.hass.data = {}  # No coordinator data — no controllable inverters
     options_flow.async_show_form = MagicMock(
         return_value={"type": "form", "step_id": "init"}
     )
@@ -377,6 +379,8 @@ async def test_options_flow_show_form(mock_ha_environment):
     config_entry.options = {"update_interval": 10}
 
     options_flow = config_flow_mod.HyxiOptionsFlowHandler(config_entry)
+    options_flow.hass = MagicMock()
+    options_flow.hass.data = {}  # No coordinator data — no controllable inverters
     options_flow.async_show_form = MagicMock(
         return_value={"type": "form", "step_id": "init"}
     )
@@ -404,7 +408,8 @@ async def test_options_flow_success(mock_ha_environment):
     result = await options_flow.async_step_init(user_input=user_input)
 
     assert result["type"] == "create_entry"
-    options_flow.async_create_entry.assert_called_once_with(title="", data=user_input)
+    call_kwargs = options_flow.async_create_entry.call_args.kwargs
+    assert call_kwargs["data"]["update_interval"] == 30
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -148,27 +148,31 @@ async def test_async_update_data_success():
 
 @pytest.mark.asyncio
 async def test_async_update_data_empty_telemetry():
-    """Test that empty telemetry raises UpdateFailed."""
+    """Test that empty telemetry warns but does not raise UpdateFailed."""
     mock_entry = MagicMock()
     mock_entry.options = {"update_interval": 5}
     mock_client = MagicMock()
-    # Device with empty metrics (only last_seen) should trigger UpdateFailed
+    # Device with empty metrics (only last_seen) — should warn, not fail
     mock_client.get_all_device_data = AsyncMock(
         return_value={
             "data": {"SN123": {"metrics": {"last_seen": "2026-05-22"}}},
             "attempts": 1,
         }
     )
+    mock_client._request = AsyncMock(  # pylint: disable=protected-access
+        return_value=(200, {"success": False})
+    )
 
     coordinator = hc_coord.HyxiDataUpdateCoordinator(
         MagicMock(), mock_client, mock_entry
     )
 
-    with pytest.raises(hc_coord.UpdateFailed) as excinfo:
-        await coordinator._async_update_data()
+    result = await coordinator._async_update_data()
 
-    assert "HYXI telemetry data is currently unavailable." in str(excinfo.value)
-    assert coordinator.hyxi_metadata["api_status"] == "Error"
+    # Data returned despite empty telemetry — no UpdateFailed, no backoff
+    assert "SN123" in result
+    assert coordinator.hyxi_metadata["api_status"] == "Online"
+    assert coordinator.hyxi_metadata["last_success"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_energy_manager_entities.py
+++ b/tests/test_energy_manager_entities.py
@@ -1,0 +1,289 @@
+"""Tests for Energy Manager entity setup and definitions."""
+
+import ast
+import json
+import re
+from pathlib import Path
+
+_CONST_PATH = Path(__file__).parent / "../custom_components/hyxi_cloud/const.py"
+
+
+def _read_const() -> str:
+    """Read const.py as text."""
+    return _CONST_PATH.read_text(encoding="utf-8")
+
+
+def _get_em_defaults() -> dict:
+    """Parse EM_DEFAULTS dict from const.py using ast.literal_eval."""
+    content = _read_const()
+    match = re.search(
+        r"EM_DEFAULTS:\s*dict\[.*?\]\s*=\s*(\{.*?\})",
+        content,
+        re.DOTALL,
+    )
+    assert match, "Could not find EM_DEFAULTS in const.py"
+    return ast.literal_eval(match.group(1))
+
+
+def _get_conf_keys() -> tuple[str, str, str]:
+    """Parse CONF_EM_* string assignments from const.py."""
+    content = _read_const()
+    keys = {}
+    for var in ("CONF_EM_ENABLED", "CONF_EM_INVERTER_SN", "CONF_EM_P1_ENTITY"):
+        match = re.search(rf'^{var}\s*=\s*"([^"]+)"', content, re.MULTILINE)
+        assert match, f"Could not find {var} in const.py"
+        keys[var] = match.group(1)
+    return (
+        keys["CONF_EM_ENABLED"],
+        keys["CONF_EM_INVERTER_SN"],
+        keys["CONF_EM_P1_ENTITY"],
+    )
+
+
+def _parse_em_number_defs():
+    """Parse EM_NUMBER_DEFS from number.py without importing (avoids HA metaclass issues).
+
+    Returns list of dicts with keys: key, unit, min_val, max_val, step, icon.
+    """
+    path = Path(__file__).parent / "../custom_components/hyxi_cloud/number.py"
+    content = path.read_text(encoding="utf-8")
+
+    # Find the EM_NUMBER_DEFS list block
+    match = re.search(
+        r"EM_NUMBER_DEFS:\s*list\[EMNumberDef\]\s*=\s*\[(.*?)\]",
+        content,
+        re.DOTALL,
+    )
+    if not match:
+        return []
+
+    block = match.group(1)
+    defs = []
+    # Parse each EMNumberDef(...) call
+    for m in re.finditer(
+        r'EMNumberDef\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*([^,]+)\s*,'
+        r"\s*([^,]+)\s*,\s*([^,]+)\s*,\s*\"([^\"]+)\"\s*\)",
+        block,
+    ):
+        defs.append(
+            {
+                "key": m.group(1),
+                "unit": m.group(2),
+                "min_val": float(m.group(3)),
+                "max_val": float(m.group(4)),
+                "step": float(m.group(5)),
+                "icon": m.group(6),
+            }
+        )
+    return defs
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# EM Constants
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEMConstants:
+    """Test EM constant definitions."""
+
+    def test_em_defaults_has_all_required_keys(self):
+        """EM_DEFAULTS should have all 15 parameter keys (not soc_min/soc_max, not battery_capacity_wh)."""
+        required_keys = [
+            "night_buffer_pct",
+            "high_load_threshold",
+            "max_charge_power",
+            "max_discharge_power",
+            "min_solar_for_charge",
+            "mode_switch_cooldown",
+            "power_change_threshold",
+            "power_adjust_cooldown",
+            "avg_night_consumption",
+            "charge_margin",
+            "charge_entry_threshold",
+            "charge_reentry_delay",
+            "bottomout_cooldown",
+            "p1_smoothing_period",
+            "max_grid_export",
+        ]
+        em_defaults = _get_em_defaults()
+        for key in required_keys:
+            assert key in em_defaults, f"Missing EM_DEFAULTS key: {key}"
+
+    def test_em_defaults_does_not_include_soc_limits(self):
+        """EM_DEFAULTS must NOT include soc_min/soc_max — those come from protection."""
+        em_defaults = _get_em_defaults()
+        assert "soc_min" not in em_defaults
+        assert "soc_max" not in em_defaults
+
+    def test_em_defaults_does_not_include_battery_capacity(self):
+        """EM_DEFAULTS must NOT include battery_capacity_wh — set in options flow."""
+        em_defaults = _get_em_defaults()
+        assert "battery_capacity_wh" not in em_defaults
+
+    def test_em_defaults_values_are_reasonable(self):
+        """EM_DEFAULTS values should be within sane ranges."""
+        em_defaults = _get_em_defaults()
+        assert em_defaults["max_charge_power"] > 0
+        assert em_defaults["max_discharge_power"] > 0
+        assert em_defaults["mode_switch_cooldown"] >= 10
+        assert em_defaults["night_buffer_pct"] >= 0
+        assert em_defaults["high_load_threshold"] > 0
+
+    def test_conf_keys_are_strings(self):
+        """Config option keys should be non-empty strings."""
+        conf_em_enabled, conf_em_inverter_sn, conf_em_p1_entity = _get_conf_keys()
+        assert isinstance(conf_em_enabled, str) and conf_em_enabled
+        assert isinstance(conf_em_inverter_sn, str) and conf_em_inverter_sn
+        assert isinstance(conf_em_p1_entity, str) and conf_em_p1_entity
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# EM Number Definitions
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEMNumberDefinitions:
+    """Test EM number entity definitions."""
+
+    def test_em_number_defs_match_defaults(self):
+        """Every EM number def key should have a matching EM_DEFAULTS entry."""
+        em_defs = _parse_em_number_defs()
+        em_defaults = _get_em_defaults()
+        assert len(em_defs) > 0, "Could not parse EM_NUMBER_DEFS from number.py"
+
+        for numdef in em_defs:
+            assert numdef["key"] in em_defaults, (
+                f"EM_NUMBER_DEFS key '{numdef['key']}' not in EM_DEFAULTS"
+            )
+
+    def test_em_number_defs_ranges_valid(self):
+        """Min should be less than max, step should be positive."""
+        em_defs = _parse_em_number_defs()
+        em_defaults = _get_em_defaults()
+        assert len(em_defs) > 0
+
+        for numdef in em_defs:
+            assert numdef["min_val"] < numdef["max_val"], (
+                f"Invalid range for '{numdef['key']}': {numdef['min_val']} >= {numdef['max_val']}"
+            )
+            assert numdef["step"] > 0, (
+                f"Invalid step for '{numdef['key']}': {numdef['step']}"
+            )
+            default = em_defaults[numdef["key"]]
+            assert numdef["min_val"] <= default <= numdef["max_val"], (
+                f"Default {default} outside range [{numdef['min_val']}, {numdef['max_val']}] for '{numdef['key']}'"
+            )
+
+    def test_em_number_defs_have_icons(self):
+        """Every EM number should have an mdi icon."""
+        em_defs = _parse_em_number_defs()
+        assert len(em_defs) > 0
+
+        for numdef in em_defs:
+            assert numdef["icon"].startswith("mdi:"), (
+                f"Invalid icon for '{numdef['key']}': {numdef['icon']}"
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Translation Coverage for EM Entities
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEMTranslationCoverage:
+    """Verify all EM entities have translations."""
+
+    @staticmethod
+    def _load_strings():
+        path = Path(__file__).parent / "../custom_components/hyxi_cloud/strings.json"
+        with path.open(encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_em_number_keys_in_strings(self):
+        """Every EM number translation_key should exist in strings.json."""
+        em_defs = _parse_em_number_defs()
+        assert len(em_defs) > 0
+
+        strings = self._load_strings()
+        number_translations = strings.get("entity", {}).get("number", {})
+
+        # EM numbers use translation_key = f"em_{key}"
+        for numdef in em_defs:
+            tk = f"em_{numdef['key']}"
+            assert tk in number_translations, (
+                f"Number translation key '{tk}' missing from strings.json"
+            )
+
+    def test_em_switch_keys_in_strings(self):
+        """EM switch translation keys should exist in strings.json."""
+        strings = self._load_strings()
+        switch_translations = strings.get("entity", {}).get("switch", {})
+
+        for key in (
+            "em_enabled",
+            "em_grid_charge_allowed",
+            "em_high_load_battery_assist",
+            "em_night_mode",
+            "em_export_limiting",
+        ):
+            assert key in switch_translations, (
+                f"Switch translation key '{key}' missing from strings.json"
+            )
+
+    def test_em_sensor_keys_in_strings(self):
+        """EM sensor translation keys should exist in strings.json."""
+        strings = self._load_strings()
+        sensor_translations = strings.get("entity", {}).get("sensor", {})
+
+        em_keys = [
+            "em_current_decision",
+            "em_last_action",
+            "em_battery_energy_available",
+            "em_hours_until_sunrise",
+            "em_hours_until_sunset",
+            "em_p1_average",
+        ]
+        for key in em_keys:
+            assert key in sensor_translations, (
+                f"Sensor translation key '{key}' missing from strings.json"
+            )
+
+    def test_em_binary_sensor_keys_in_strings(self):
+        """EM binary sensor translation keys should exist in strings.json."""
+        strings = self._load_strings()
+        bs_translations = strings.get("entity", {}).get("binary_sensor", {})
+
+        for key in ("em_night_mode_active", "em_high_load_detected"):
+            assert key in bs_translations, (
+                f"Binary sensor translation key '{key}' missing from strings.json"
+            )
+
+    def test_em_options_step_in_strings(self):
+        """Energy manager options step should exist in strings.json."""
+        strings = self._load_strings()
+        options_steps = strings.get("options", {}).get("step", {})
+        assert "energy_manager" in options_steps, (
+            "Missing 'energy_manager' options step in strings.json"
+        )
+        em_step = options_steps["energy_manager"]
+        assert "data" in em_step
+        assert "em_inverter_sn" in em_step["data"]
+        assert "em_p1_entity" in em_step["data"]
+        assert "em_battery_capacity_override" in em_step["data"]
+        assert "em_battery_capacity_wh" in em_step["data"]
+        assert "em_dry_run" in em_step["data"]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Config Flow EM Step
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestConfigFlowEM:
+    """Test the config flow EM options step data keys."""
+
+    def test_em_enabled_in_init_step_data(self):
+        """The init step should include enable_energy_manager in its data translations."""
+        strings = TestEMTranslationCoverage._load_strings()
+        init_data = strings["options"]["step"]["init"]["data"]
+        assert "enable_energy_manager" in init_data

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,827 @@
+"""Tests for the Energy Manager decision engine.
+
+The real engine.py imports HA modules that are hard to mock at import time.
+Instead of fighting the import system, we embed the decision logic directly
+in FakeEngine — it's a 1:1 copy of _make_decision from engine.py.  This
+tests the priority logic, cooldowns, and state transitions without HA.
+
+If engine.py _make_decision changes, update the copy here.
+"""
+
+import time
+from collections import deque
+from dataclasses import dataclass
+
+import pytest
+
+# ── Helpers to build a testable engine without real HA ──────────────────
+
+
+@dataclass
+class DecisionState:
+    """Snapshot of current system state for the decision engine."""
+
+    soc: float
+    solar: float
+    p1: float
+    home_load: float
+    soc_min: float
+    soc_max: float
+    max_charge: float
+    max_discharge: float
+    is_night: bool
+    solar_producing: bool
+    night_soc_target: float
+
+
+@dataclass
+class SolarConfig:
+    """Computed solar charge parameters for a single decision tick."""
+
+    min_solar_for_charge: float
+    charge_margin: float
+    charge_entry_threshold: float
+    readings_needed: int
+    sunset_urgent: bool
+
+
+@dataclass
+class FakeEngineConfig:
+    """Configuration for FakeEngine — keeps __init__ argument count low."""
+
+    soc: float = 50.0
+    solar: float = 0.0
+    home_load: float = 0.0
+    p1: float = 0.0
+    is_night: bool = False
+    current_mode: str | None = None
+    soc_min: float = 20.0
+    soc_max: float = 90.0
+    max_charge: float = 5000.0
+    max_discharge: float = 5000.0
+    grid_charge_allowed: bool = False
+    high_load_assist: bool = True
+    night_mode_enabled: bool = True
+
+
+class FakeEngine:
+    """Stripped-down engine that replicates decision logic without HA imports."""
+
+    def __init__(self, **kwargs):
+        cfg = FakeEngineConfig(**kwargs)
+        self.soc = cfg.soc
+        self.solar = cfg.solar
+        self.home_load = cfg.home_load
+        self.p1 = cfg.p1
+        self._is_night_val = cfg.is_night
+        self.soc_min = cfg.soc_min
+        self.soc_max = cfg.soc_max
+        self.max_charge = cfg.max_charge
+        self.max_discharge = cfg.max_discharge
+        self.grid_charge_allowed = cfg.grid_charge_allowed
+        self.high_load_assist = cfg.high_load_assist
+        self.night_mode_enabled = cfg.night_mode_enabled
+
+        # Engine state
+        self._sn = "TEST_SN"
+        self._current_mode = cfg.current_mode
+        self._last_decision = ""
+        self._last_action = ""
+        self._last_mode_switch: float = 0
+        self._last_power_adjust: float = 0
+        self._last_charge_exit: float = 0
+        self._last_bottomout_exit: float = 0
+        self._charge_entry_export_count = 0
+        self._charge_bottomout_count = 0
+        self._p1_buffer: deque = deque()
+
+        # Track API calls
+        self.mode_calls: list = []
+        self.adjust_calls: list = []
+
+        # EM params — does NOT include soc_min/soc_max (those come from protection)
+        # battery_capacity_wh handled by _get_battery_capacity(), not params
+        self.battery_capacity_wh = 14800  # Default for tests
+        self.params = {
+            "max_charge_power": cfg.max_charge,
+            "max_discharge_power": cfg.max_discharge,
+            "high_load_threshold": 6500,
+            "mode_switch_cooldown": 60,
+            "power_change_threshold": 100,
+            "power_adjust_cooldown": 30,
+            "avg_night_consumption": 400,
+            "night_buffer_pct": 5,
+            "min_solar_for_charge": 1000,
+            "charge_margin": 150,
+            "charge_entry_threshold": 500,
+            "charge_reentry_delay": 300,
+            "bottomout_cooldown": 300,
+        }
+
+        # Protection params — read from existing protection number entities
+        self.protection_params = {
+            "soc_min": cfg.soc_min,
+            "soc_max": cfg.soc_max,
+        }
+
+    def _get_soc(self):
+        return self.soc
+
+    def _get_solar(self):
+        return self.solar
+
+    def _get_home_load(self):
+        return self.home_load
+
+    def _get_p1(self):
+        return self.p1
+
+    def _is_night(self):
+        return self._is_night_val
+
+    def _get_battery_capacity(self):
+        return float(self.battery_capacity_wh)
+
+    def _get_param(self, key):
+        if key == "battery_capacity_wh":
+            return self._get_battery_capacity()
+        return float(self.params.get(key, 0))
+
+    def _get_protection_param(self, key, default):
+        """Read from existing protection number entities (soc_min, soc_max)."""
+        return float(self.protection_params.get(key, default))
+
+    def _soc_needed_for_night(self):
+        wh_needed = self._get_param("avg_night_consumption") * 12 * 1.05
+        capacity = self._get_param("battery_capacity_wh")
+        soc_min = self._get_protection_param("soc_min", 20)
+        if capacity <= 0:
+            capacity = 10000
+        return soc_min + (wh_needed / capacity) * 100
+
+    def _solar_will_cover_charge(self, target_soc):
+        return False
+
+    def _hours_until_sunset(self):
+        return 12.0
+
+    @property
+    def p1_avg(self):
+        if not self._p1_buffer:
+            return 0.0
+        return sum(v for _, v in self._p1_buffer) / len(self._p1_buffer)
+
+    def _get_current_power_setting(self, direction):
+        return 0.0
+
+    def _find_entity_id(self, domain, unique_id):
+        return unique_id  # Return the unique_id as the entity_id for matching
+
+    def _get_ha_state_bool(self, entity_id, default=False):
+        if "grid_charge_allowed" in str(entity_id or ""):
+            return self.grid_charge_allowed
+        if "high_load_battery_assist" in str(entity_id or ""):
+            return self.high_load_assist
+        if "em_night_mode" in str(entity_id or ""):
+            return self.night_mode_enabled
+        return default
+
+    def _set_decision(self, decision):
+        self._last_decision = decision
+
+    async def _set_mode(self, mode, power_w=None):
+        self.mode_calls.append((mode, power_w))
+        self._current_mode = mode
+        self._last_mode_switch = time.monotonic()
+        if power_w:
+            self._last_action = f"{mode} @ {power_w}W"
+        else:
+            self._last_action = mode
+        return True
+
+    async def _adjust_power(self, direction, target_w):
+        self.adjust_calls.append((direction, target_w))
+        self._last_power_adjust = time.monotonic()
+        return True
+
+    def _notify_sensors(self):
+        pass
+
+    # ── Decision logic — 1:1 copy from engine.py ────────────────────────
+    # Keep in sync with custom_components/hyxi_cloud/engine.py
+
+    async def _make_decision(self) -> None:
+        solar = self._get_solar()
+        s = DecisionState(
+            soc=self._get_soc(),
+            solar=solar,
+            p1=self._get_p1(),
+            home_load=self._get_home_load(),
+            soc_min=self._get_protection_param("soc_min", 20),
+            soc_max=self._get_protection_param("soc_max", 90),
+            max_charge=self._get_param("max_charge_power"),
+            max_discharge=self._get_param("max_discharge_power"),
+            is_night=self._is_night(),
+            solar_producing=solar > 50,
+            night_soc_target=self._soc_needed_for_night(),
+        )
+
+        # PRIORITY 1 & 2: SOC safety limits
+        if await self._check_soc_limits(s):
+            return
+        # PRIORITY 3: Sustained high load
+        if await self._check_high_load(s):
+            return
+        # PRIORITY 4 & 4b: Night mode
+        if await self._check_night(s):
+            return
+        # PRIORITY 5: Solar optimization
+        if await self._check_solar(s):
+            return
+
+        # DEFAULT: self_consume as safe fallback
+        self._set_decision("idle_default")
+        if self._current_mode in ("charge", "discharge"):
+            await self._set_mode("self_consume")
+
+    async def _check_soc_limits(self, s: DecisionState) -> bool:
+        """PRIORITY 1: Emergency SOC below minimum. PRIORITY 2: SOC above maximum."""
+        if s.soc < s.soc_min:
+            if s.solar_producing:
+                charge_target = min(s.solar - 50, s.max_charge)
+                charge_target = max(charge_target, 300)
+                self._set_decision("emergency_solar_charge")
+                if self._current_mode != "charge":
+                    await self._set_mode("charge", int(charge_target))
+                else:
+                    await self._adjust_power("charge", int(charge_target))
+                return True
+
+            grid_charge_uid = f"hyxi_{self._sn}_em_grid_charge_allowed"
+            grid_entity = self._find_entity_id("switch", grid_charge_uid)
+            if self._get_ha_state_bool(grid_entity):
+                grid_charge_w = min(2000, int(s.max_charge))
+                self._set_decision("grid_charge_emergency")
+                if self._current_mode != "charge":
+                    await self._set_mode("charge", grid_charge_w)
+                else:
+                    await self._adjust_power("charge", grid_charge_w)
+                return True
+            self._set_decision("low_soc_idle")
+            if self._current_mode != "idle":
+                await self._set_mode("idle")
+            return True
+
+        # SOC above maximum — force discharge
+        if s.soc > s.soc_max:
+            discharge_w = max(s.p1, 1000)
+            discharge_w = min(discharge_w, s.max_discharge)
+            self._set_decision("forced_discharge_over_max")
+            if self._current_mode != "discharge":
+                await self._set_mode("discharge", int(discharge_w))
+            else:
+                await self._adjust_power("discharge", int(discharge_w))
+            return True
+
+        return False
+
+    async def _check_high_load(self, s: DecisionState) -> bool:
+        """PRIORITY 3: Sustained high load — battery assist or grid only."""
+        # Check if high load feature is enabled by the user
+        high_load_assist_uid = f"hyxi_{self._sn}_em_high_load_battery_assist"
+        high_load_entity = self._find_entity_id("switch", high_load_assist_uid)
+        high_load_assist = self._get_ha_state_bool(high_load_entity, False)
+        if not high_load_assist:
+            return False
+
+        high_load_threshold = self._get_param("high_load_threshold")
+
+        if s.home_load > high_load_threshold:
+            high_load_wh = s.max_discharge * 0.5
+            capacity = self._get_param("battery_capacity_wh")
+            soc_cost = (high_load_wh / capacity) * 100 if capacity > 0 else 100
+
+            if (s.soc - soc_cost) > s.night_soc_target:
+                self._set_decision("high_load_battery_assist")
+                if self._current_mode != "self_consume":
+                    await self._set_mode("self_consume")
+            else:
+                self._set_decision("high_load_grid_only")
+                if self._current_mode != "idle":
+                    await self._set_mode("idle")
+            return True
+
+        return False
+
+    async def _check_night(self, s: DecisionState) -> bool:
+        """PRIORITY 4: Night self_consume/idle. PRIORITY 4b: Night battery preservation."""
+        # Check if night mode feature is enabled by the user
+        night_mode_uid = f"hyxi_{self._sn}_em_night_mode"
+        night_mode_entity = self._find_entity_id("switch", night_mode_uid)
+        if not self._get_ha_state_bool(night_mode_entity, False):
+            return False
+
+        if not s.solar_producing and s.is_night:
+            if s.soc > s.soc_min:
+                self._set_decision("night_self_consume")
+                if self._current_mode != "self_consume":
+                    await self._set_mode("self_consume")
+            else:
+                self._set_decision("night_reserve_hold")
+                if self._current_mode != "idle":
+                    await self._set_mode("idle")
+            return True
+
+        # Night battery preservation during daytime
+        p1_avg = self.p1_avg
+        if (
+            not s.is_night
+            and s.soc <= s.night_soc_target
+            and s.p1 > 0
+            and p1_avg > 0
+            and not self._solar_will_cover_charge(s.night_soc_target)
+        ):
+            self._set_decision("night_preserve_idle")
+            if self._current_mode != "idle":
+                await self._set_mode("idle")
+            return True
+
+        return False
+
+    async def _check_solar(self, s: DecisionState) -> bool:
+        """PRIORITY 5: Solar charge entry/exit and battery full."""
+        if s.solar_producing and s.soc < s.soc_max:
+            await self._solar_charge_logic(s)
+            return True
+
+        if s.solar_producing and s.soc >= s.soc_max:
+            self._set_decision("solar_battery_full")
+            if self._current_mode != "self_consume":
+                await self._set_mode("self_consume")
+            return True
+
+        return False
+
+    async def _solar_charge_logic(self, s: DecisionState) -> None:
+        """Solar charge entry/exit and power tuning logic."""
+        min_solar_for_charge = self._get_param("min_solar_for_charge")
+        charge_margin = self._get_param("charge_margin")
+        charge_entry_threshold = self._get_param("charge_entry_threshold")
+        charge_reentry_delay = self._get_param("charge_reentry_delay")
+        readings_needed = max(int(charge_reentry_delay / 15 / 3), 2)
+
+        # After a bottomout exit, double the readings needed
+        bottomout_cooldown = self._get_param("bottomout_cooldown")
+        if (time.monotonic() - self._last_bottomout_exit) < bottomout_cooldown:
+            readings_needed = readings_needed * 2
+
+        # Sunset urgency
+        hours_to_sunset = self._hours_until_sunset()
+        sunset_urgent = False
+        if hours_to_sunset < 4 and s.soc < s.night_soc_target:
+            if not self._solar_will_cover_charge(s.night_soc_target):
+                sunset_urgent = True
+                charge_entry_threshold = max(charge_entry_threshold // 2, 100)
+                readings_needed = max(readings_needed // 2, 1)
+                min_solar_for_charge = max(min_solar_for_charge - 300, 200)
+
+        sc = SolarConfig(
+            min_solar_for_charge=min_solar_for_charge,
+            charge_margin=charge_margin,
+            charge_entry_threshold=charge_entry_threshold,
+            readings_needed=readings_needed,
+            sunset_urgent=sunset_urgent,
+        )
+
+        if self._current_mode != "charge":
+            await self._solar_entry_logic(s, sc)
+        else:
+            # In charge mode: fine-tune power, cap at solar, exit if sustained import
+            await self._solar_tune_logic(s, sc)
+
+    async def _solar_entry_logic(
+        self,
+        s: DecisionState,
+        sc: SolarConfig,
+    ) -> None:
+        """Handle charge entry — stay in self_consume, only charge on sustained export."""
+        if s.solar < sc.min_solar_for_charge:
+            self._set_decision("solar_self_consume")
+            if self._current_mode not in ("self_consume", "idle"):
+                await self._set_mode("self_consume")
+            self._charge_entry_export_count = 0
+
+        elif s.p1 < -sc.charge_entry_threshold:
+            self._charge_entry_export_count += 1
+            if (
+                self._charge_entry_export_count >= sc.readings_needed
+                and s.solar >= sc.min_solar_for_charge
+            ):
+                charge_target = min(abs(s.p1) - sc.charge_margin - 100, s.solar - 500)
+                charge_target = min(charge_target, s.max_charge)
+                charge_target = max(charge_target, 300)
+                decision = "pre_night_charge" if sc.sunset_urgent else "solar_charge"
+                self._set_decision(decision)
+                if await self._set_mode("charge", int(charge_target)):
+                    self._charge_entry_export_count = 0
+            else:
+                self._set_decision("solar_export_waiting")
+                if self._current_mode not in ("self_consume", "idle"):
+                    await self._set_mode("self_consume")
+        else:
+            self._charge_entry_export_count = 0
+            self._set_decision("solar_self_consume")
+            if self._current_mode not in ("self_consume", "idle"):
+                await self._set_mode("self_consume")
+
+    async def _solar_tune_logic(
+        self,
+        s: DecisionState,
+        sc: SolarConfig,
+    ) -> None:
+        """Fine-tune charge power — cap at solar, exit if sustained import."""
+        current_charge = self._get_current_power_setting("charge")
+        solar_cap = max(s.solar - sc.charge_margin, 100)
+
+        if s.solar < sc.min_solar_for_charge - 150:
+            self._set_decision("solar_self_consume")
+            self._last_charge_exit = time.monotonic()
+            self._charge_entry_export_count = 0
+            self._charge_bottomout_count = 0
+            await self._set_mode("self_consume")
+
+        elif s.p1 > sc.charge_margin:
+            await self._solar_reduce_charge(
+                s.p1, current_charge, solar_cap, sc.charge_margin
+            )
+
+        elif s.p1 < -(sc.charge_margin + 100):
+            # Exporting too much — increase charge
+            self._charge_bottomout_count = 0
+            excess_export = abs(s.p1) - sc.charge_margin
+            charge_target = current_charge + excess_export
+            charge_target = min(charge_target, s.max_charge)
+            charge_target = min(charge_target, solar_cap)
+            self._set_decision("solar_charge")
+            await self._adjust_power("charge", int(charge_target))
+        else:
+            # P1 within target range — balanced
+            self._charge_bottomout_count = 0
+            self._set_decision("solar_charge")
+
+    async def _solar_reduce_charge(
+        self,
+        p1,
+        current_charge,
+        solar_cap,
+        charge_margin,
+    ) -> None:
+        """Reduce charge power when importing from grid."""
+        charge_target = current_charge - (p1 + charge_margin)
+        charge_target = min(charge_target, solar_cap)
+        charge_target = max(charge_target, 100)
+
+        if charge_target <= 100:
+            self._charge_bottomout_count += 1
+            if self._charge_bottomout_count >= 3:
+                self._set_decision("solar_self_consume")
+                self._last_charge_exit = time.monotonic()
+                self._last_bottomout_exit = time.monotonic()
+                self._charge_entry_export_count = 0
+                self._charge_bottomout_count = 0
+                await self._set_mode("self_consume")
+            else:
+                self._set_decision("solar_charge_reduced")
+                await self._adjust_power("charge", 100)
+        else:
+            self._charge_bottomout_count = 0
+            self._set_decision("solar_charge")
+            await self._adjust_power("charge", int(charge_target))
+
+
+async def run_decision(engine):
+    """Run the decision logic on FakeEngine."""
+    await engine._make_decision()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Priority 1: Emergency low SOC
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPriority1EmergencyLowSOC:
+    """Test Priority 1: SOC below minimum triggers emergency actions."""
+
+    @pytest.mark.asyncio
+    async def test_low_soc_with_solar_charges(self):
+        """SOC below min + solar producing -> emergency solar charge."""
+        engine = FakeEngine(soc=15, solar=2000, soc_min=20)
+        await run_decision(engine)
+        assert engine._last_decision == "emergency_solar_charge"
+        assert len(engine.mode_calls) == 1
+        assert engine.mode_calls[0][0] == "charge"
+
+    @pytest.mark.asyncio
+    async def test_low_soc_no_solar_grid_allowed(self):
+        """SOC below min + no solar + grid charge allowed -> grid charge."""
+        engine = FakeEngine(soc=15, solar=0, soc_min=20, grid_charge_allowed=True)
+        await run_decision(engine)
+        assert engine._last_decision == "grid_charge_emergency"
+        assert engine.mode_calls[0][0] == "charge"
+
+    @pytest.mark.asyncio
+    async def test_low_soc_no_solar_no_grid(self):
+        """SOC below min + no solar + no grid charge -> idle."""
+        engine = FakeEngine(soc=15, solar=0, soc_min=20, grid_charge_allowed=False)
+        await run_decision(engine)
+        assert engine._last_decision == "low_soc_idle"
+        assert engine.mode_calls[0][0] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_low_soc_already_charging_adjusts_power(self):
+        """SOC below min + already in charge mode -> adjust power, don't switch."""
+        engine = FakeEngine(soc=15, solar=3000, soc_min=20, current_mode="charge")
+        await run_decision(engine)
+        assert engine._last_decision == "emergency_solar_charge"
+        assert len(engine.mode_calls) == 0  # No mode switch
+        assert len(engine.adjust_calls) == 1  # Power adjustment
+        assert engine.adjust_calls[0][0] == "charge"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Priority 2: SOC above maximum
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPriority2OverMax:
+    """Test Priority 2: SOC above maximum triggers forced discharge."""
+
+    @pytest.mark.asyncio
+    async def test_over_max_forces_discharge(self):
+        """SOC above max -> forced discharge."""
+        engine = FakeEngine(soc=95, soc_max=90, p1=500)
+        await run_decision(engine)
+        assert engine._last_decision == "forced_discharge_over_max"
+        assert engine.mode_calls[0][0] == "discharge"
+
+    @pytest.mark.asyncio
+    async def test_over_max_already_discharging_adjusts(self):
+        """SOC above max + already discharging -> adjust power."""
+        engine = FakeEngine(soc=95, soc_max=90, p1=500, current_mode="discharge")
+        await run_decision(engine)
+        assert engine._last_decision == "forced_discharge_over_max"
+        assert len(engine.mode_calls) == 0
+        assert len(engine.adjust_calls) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Priority 3: High load
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPriority3HighLoad:
+    """Test Priority 3: High home load handling."""
+
+    @pytest.mark.asyncio
+    async def test_high_load_with_sufficient_soc(self):
+        """High load + enough SOC -> battery assist (self_consume)."""
+        engine = FakeEngine(soc=80, home_load=8000, high_load_assist=True)
+        engine.params["high_load_threshold"] = 6500
+        engine.battery_capacity_wh = 14800
+        await run_decision(engine)
+        assert engine._last_decision == "high_load_battery_assist"
+        assert engine.mode_calls[0][0] == "self_consume"
+
+    @pytest.mark.asyncio
+    async def test_high_load_low_soc_goes_idle(self):
+        """High load + low SOC (would drain below night target) -> idle."""
+        engine = FakeEngine(soc=30, home_load=8000, high_load_assist=True)
+        engine.params["high_load_threshold"] = 6500
+        engine.battery_capacity_wh = 14800
+        await run_decision(engine)
+        assert engine._last_decision == "high_load_grid_only"
+        assert engine.mode_calls[0][0] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_high_load_assist_disabled(self):
+        """High load + assist disabled -> skips to next priority."""
+        engine = FakeEngine(
+            soc=70, home_load=8000, is_night=True, high_load_assist=False
+        )
+        engine.params["high_load_threshold"] = 6500
+        await run_decision(engine)
+        # Night mode enabled by default in tests, so falls through to night
+        assert engine._last_decision == "night_self_consume"
+
+    @pytest.mark.asyncio
+    async def test_high_load_assist_disabled_no_night(self):
+        """High load + assist disabled + not night -> falls to default."""
+        engine = FakeEngine(
+            soc=70, home_load=8000, high_load_assist=False, is_night=False
+        )
+        engine.params["high_load_threshold"] = 6500
+        await run_decision(engine)
+        assert engine._last_decision == "idle_default"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Priority 4: Night mode
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPriority4Night:
+    """Test Priority 4: Night mode handling."""
+
+    @pytest.mark.asyncio
+    async def test_night_soc_above_min_self_consumes(self):
+        """Night + SOC above min -> self_consume to discharge for house."""
+        engine = FakeEngine(soc=50, is_night=True, soc_min=20)
+        await run_decision(engine)
+        assert engine._last_decision == "night_self_consume"
+        assert engine.mode_calls[0][0] == "self_consume"
+
+    @pytest.mark.asyncio
+    async def test_night_soc_at_min_idles(self):
+        """Night + SOC at minimum -> idle to protect reserve."""
+        engine = FakeEngine(soc=20, is_night=True, soc_min=20)
+        await run_decision(engine)
+        assert engine._last_decision == "night_reserve_hold"
+        assert engine.mode_calls[0][0] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_night_soc_below_min_triggers_emergency(self):
+        """Night + SOC below minimum -> Priority 1 (emergency) takes over."""
+        engine = FakeEngine(soc=15, is_night=True, soc_min=20)
+        await run_decision(engine)
+        assert engine._last_decision == "low_soc_idle"
+
+    @pytest.mark.asyncio
+    async def test_night_mode_disabled_skips_night_priority(self):
+        """Night conditions met but night mode switch OFF -> skip to next priority."""
+        engine = FakeEngine(soc=50, is_night=True, soc_min=20, night_mode_enabled=False)
+        await run_decision(engine)
+        # Night mode disabled, should fall through to default
+        assert engine._last_decision == "idle_default"
+
+    @pytest.mark.asyncio
+    async def test_night_mode_disabled_high_load_still_works(self):
+        """Night mode off but high load on -> high load still triggers."""
+        engine = FakeEngine(
+            soc=80,
+            is_night=True,
+            home_load=8000,
+            night_mode_enabled=False,
+            high_load_assist=True,
+        )
+        engine.params["high_load_threshold"] = 6500
+        engine.battery_capacity_wh = 14800
+        await run_decision(engine)
+        assert engine._last_decision == "high_load_battery_assist"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Priority 5: Solar optimization
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPriority5Solar:
+    """Test Priority 5: Solar active — self_consume vs charge."""
+
+    @pytest.mark.asyncio
+    async def test_solar_low_stays_self_consume(self):
+        """Solar below min threshold -> stay in self_consume."""
+        engine = FakeEngine(soc=50, solar=500, p1=-200, soc_max=90)
+        engine.params["min_solar_for_charge"] = 1000
+        await run_decision(engine)
+        assert engine._last_decision == "solar_self_consume"
+
+    @pytest.mark.asyncio
+    async def test_solar_exporting_counts_before_charge(self):
+        """Heavy export -> counts up, doesn't immediately charge."""
+        engine = FakeEngine(soc=50, solar=3000, p1=-1000, soc_max=90)
+        engine.params["min_solar_for_charge"] = 1000
+        engine.params["charge_entry_threshold"] = 500
+        await run_decision(engine)
+        # First tick should just count, not switch to charge
+        assert engine._charge_entry_export_count == 1
+        assert engine._last_decision == "solar_export_waiting"
+
+    @pytest.mark.asyncio
+    async def test_solar_battery_full_self_consumes(self):
+        """Solar + SOC at max -> self_consume (battery full)."""
+        engine = FakeEngine(soc=90, solar=3000, soc_max=90)
+        await run_decision(engine)
+        assert engine._last_decision == "solar_battery_full"
+        assert engine.mode_calls[0][0] == "self_consume"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Default fallback
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestDefaultFallback:
+    """Test default behavior when no priority matches."""
+
+    @pytest.mark.asyncio
+    async def test_default_idle_from_charge(self):
+        """No conditions match + in charge mode -> switch to self_consume."""
+        engine = FakeEngine(soc=50, solar=0, current_mode="charge")
+        await run_decision(engine)
+        assert engine._last_decision == "idle_default"
+        assert engine.mode_calls[0][0] == "self_consume"
+
+    @pytest.mark.asyncio
+    async def test_default_already_self_consume(self):
+        """No conditions match + already in self_consume -> no mode switch."""
+        engine = FakeEngine(soc=50, solar=0, current_mode="self_consume")
+        await run_decision(engine)
+        assert engine._last_decision == "idle_default"
+        assert len(engine.mode_calls) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# P1 rolling average
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestP1RollingAverage:
+    """Test the P1 rolling average buffer."""
+
+    def test_empty_buffer_returns_zero(self):
+        engine = FakeEngine()
+        assert engine.p1_avg == 0.0
+
+    def test_single_value(self):
+        engine = FakeEngine()
+        engine._p1_buffer.append((time.monotonic(), 500.0))
+        assert engine.p1_avg == 500.0
+
+    def test_multiple_values_averaged(self):
+        engine = FakeEngine()
+        now = time.monotonic()
+        engine._p1_buffer.append((now, 100.0))
+        engine._p1_buffer.append((now, 200.0))
+        engine._p1_buffer.append((now, 300.0))
+        assert engine.p1_avg == 200.0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Night consumption estimation
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNightEstimation:
+    """Test night SOC target calculation."""
+
+    def test_soc_needed_includes_buffer(self):
+        """Night SOC target should be soc_min + energy needed."""
+        engine = FakeEngine(soc_min=20)
+        engine.params["avg_night_consumption"] = 400
+        engine.battery_capacity_wh = 14800  # override for this test
+        engine.params["night_buffer_pct"] = 5
+        target = engine._soc_needed_for_night()
+        # soc_min(20) + (400 * 12 * 1.05 / 14800) * 100 ≈ 20 + 34.05 ≈ 54
+        assert target > engine.soc_min
+        assert target < 100
+
+    def test_soc_needed_with_zero_capacity(self):
+        """Zero capacity should use fallback of 10000."""
+        engine = FakeEngine(soc_min=20)
+        engine.battery_capacity_wh = 0
+        target = engine._soc_needed_for_night()
+        assert target > 20  # Should still compute something reasonable
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Charge bottomout counter
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestChargeBottomout:
+    """Test charge mode exit via sustained bottomout."""
+
+    @pytest.mark.asyncio
+    async def test_bottomout_counter_increments(self):
+        """Importing while in charge mode -> bottomout counter goes up."""
+        engine = FakeEngine(
+            soc=50, solar=1200, p1=500, current_mode="charge", soc_max=90
+        )
+        engine.params["charge_margin"] = 150
+        engine.params["min_solar_for_charge"] = 1000
+        await run_decision(engine)
+        assert engine._charge_bottomout_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_three_bottomouts_exits_to_self_consume(self):
+        """Three consecutive bottomouts -> exit charge to self_consume."""
+        engine = FakeEngine(
+            soc=50, solar=1200, p1=2000, current_mode="charge", soc_max=90
+        )
+        engine.params["charge_margin"] = 150
+        engine.params["min_solar_for_charge"] = 1000
+        engine._charge_bottomout_count = 2  # Already at 2, next will be 3
+
+        await run_decision(engine)
+        assert engine._last_decision == "solar_self_consume"
+        assert engine.mode_calls[0][0] == "self_consume"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -121,6 +121,7 @@ def mock_entry():
         CONF_ACCESS_KEY: "test_access",
         CONF_SECRET_KEY: "test_secret",
     }
+    entry.options = {}  # Empty options — no EM enabled
     entry.entry_id = "test_id"
     entry.add_update_listener = MagicMock()
     entry.async_on_unload = MagicMock()
@@ -141,6 +142,7 @@ async def test_async_setup_entry_success(mock_hass, mock_entry):
     ):
         mock_coordinator = mock_coordinator_class.return_value
         mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.engine = None  # No EM engine
         mock_coordinator.data = {
             "TEST_SN_1": {
                 "device_name": "Test Device 1",
@@ -211,6 +213,7 @@ async def test_async_setup_entry_parent_link(mock_hass, mock_entry):
     ):
         mock_coordinator = mock_coordinator_class.return_value
         mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.engine = None  # No EM engine
         mock_coordinator.data = {
             "CHILD_SN_1": {
                 "device_name": "Child Device",
@@ -316,7 +319,10 @@ async def test_async_setup_entry_missing_keys(mock_hass):
 @pytest.mark.asyncio
 async def test_async_unload_entry_success(mock_hass, mock_entry):
     """Test successful unload of a config entry."""
-    mock_hass.data[DOMAIN] = {mock_entry.entry_id: MagicMock()}
+    mock_coordinator = MagicMock()
+    mock_coordinator.protection_controllers = {}
+    mock_coordinator.engine = None
+    mock_hass.data[DOMAIN] = {mock_entry.entry_id: mock_coordinator}
     mock_hass.config_entries.async_unload_platforms.return_value = True
 
     assert await async_unload_entry(mock_hass, mock_entry) is True
@@ -330,7 +336,10 @@ async def test_async_unload_entry_success(mock_hass, mock_entry):
 @pytest.mark.asyncio
 async def test_async_unload_entry_failure(mock_hass, mock_entry):
     """Test failed unload of a config entry."""
-    mock_hass.data[DOMAIN] = {mock_entry.entry_id: MagicMock()}
+    mock_coordinator = MagicMock()
+    mock_coordinator.protection_controllers = {}
+    mock_coordinator.engine = None
+    mock_hass.data[DOMAIN] = {mock_entry.entry_id: mock_coordinator}
     mock_hass.config_entries.async_unload_platforms.return_value = False
 
     assert await async_unload_entry(mock_hass, mock_entry) is False
@@ -376,6 +385,7 @@ async def test_async_setup_entry_battery_first_class_device(mock_hass, mock_entr
     ):
         mock_coordinator = mock_coordinator_class.return_value
         mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.engine = None  # No EM engine
         mock_coordinator.data = {
             # Inverter knows about its battery via metrics
             "INVERTER_SN": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -36,6 +36,14 @@ def get_translation_keys():
         for k in attr_keys:
             keys["sensor"].add(k.lower())
 
+        # Find f-string translation keys like self._attr_translation_key = f"em_{...}"
+        fstring_keys = re.findall(r'_attr_translation_key\s*=\s*f"em_\{', content)
+        if fstring_keys:
+            # Resolve from EMSensorDef instantiations (first positional arg is key)
+            em_keys = re.findall(r'EMSensorDef\(\s*"([^"]+)"', content)
+            for k in em_keys:
+                keys["sensor"].add(f"em_{k}".lower())
+
     # 2. Binary Sensors from binary_sensor.py
     binary_path = (
         Path(__file__).parent / "../custom_components/hyxi_cloud/binary_sensor.py"
@@ -46,6 +54,16 @@ def get_translation_keys():
         binary_keys = re.findall(r'_attr_translation_key = "([^"]+)"', content)
         for k in binary_keys:
             keys["binary_sensor"].add(k.lower())
+
+        # Find f-string translation keys like self._attr_translation_key = f"em_{key}"
+        fstring_keys = re.findall(r'_attr_translation_key\s*=\s*f"em_\{', content)
+        if fstring_keys:
+            # Resolve from EMBinarySensor instantiation lines
+            for line in content.splitlines():
+                if "EMBinarySensor(" in line:
+                    m = re.search(r'"([a-z_]+)"', line)
+                    if m:
+                        keys["binary_sensor"].add(f"em_{m.group(1)}".lower())
 
     return keys
 


### PR DESCRIPTION
  🛰️  HYXi Cloud PR
  ⏺ 📝 Description                                                                                                                                                                                                                                 
           
  Add the Energy Manager Standalone — an automated battery control engine that runs a configurable decision loop inside Home Assistant. It reads the P1 smart meter, solar production, battery SOC, and optional solar forecast to manage the    
  inverter's operating mode (charge, discharge, self-consume, idle) without external scripts or HA automation dependencies.                                                                                                                      
                                                                                                                                                                                                                                                 
  Key features:
  - Priority-based decision engine (emergency SOC → export limiting → high load assist → night mode → solar optimization → self-consume fallback)                                                                                              
  - Export Limiting — caps grid export by charging battery with excess power; on supported single-phase devices (controlId 1021) curtails PV production when battery is full
  - Night Mode — manages battery during nighttime with automatic night SOC target calculation                                                                               
  - High Load Battery Assist — detects high home consumption and decides battery vs grid                                                                                                                                                         
  - Solar charge optimization — sustained export confirmation, continuous power tuning, bottomout detection, sunset urgency
  - Dry-Run Mode — logs all decisions and fires HA events but skips API calls                                                                                                                                                                    
  - Configurable loop interval (5–60s, default 15s) via options flow                                                                                                                                                                             
  - All features gated behind individual toggle switches (default OFF)                                                                                                                                                                         
  - Translation strings added for all supported languages                                                                                                                                                                                        
                                                                                                                                                                                                                                                 
  💡 Rationale                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                 
  - All parameters configurable via HA UI (options flow + number/switch entities)
  - Reads existing protection number entities (SOC min/max) — no duplication                                                                                                                                                                   
  - Fires hyxi_em_mode_changed HA events for automation integration                                                                                                                                                                              
  - Dry-run mode enables safe testing before live deployment
  - RestoreEntity support — all settings survive HA restarts                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
  📁 New files:                                                                                                                                                                                                                                
  - engine.py — 1174-line decision engine with 5-priority system                                                                                                                                                                                 
  - test_engine.py — 831 lines of engine unit tests (priority 1–5, P1 averaging, night estimation, bottomout)
  - test_energy_manager_entities.py — 289 lines testing constants, number defs, translation coverage                                                                                                                                           
                                                                                                                                                                                                                                                 
  Modified files:
  - __init__.py — engine lifecycle (start/stop on entry load/unload)                                                                                                                                                                             
  - config_flow.py — options flow: EM toggle, energy_manager step (P1 entity, forecast, inverter SN, battery capacity override, loop interval, dry-run)                                                                                          
  - const.py — EM config keys, EM_DEFAULTS (15 parameters), loop interval constant                                                                                                                                                             
  - sensor.py — 7 new EM sensors (status, decision, last action, battery energy, sunrise/sunset hours, P1 average)                                                                                                                               
  - binary_sensor.py — 2 new EM binary sensors (night mode active, high load detected)                                                                                                                                                           
  - switch.py — 5 new EM toggle switches (enabled, night mode, high load assist, grid charge, export limiting)                                                                                                                                 
  - number.py — 15 new EM parameter numbers (thresholds, cooldowns, power limits)                                                                                                                                                                
  - strings.json + 20 translation files — all new entity translations
  - README.md — full EM documentation with priority table, feature details, entity reference                                                                                                                                                     
           
  ---                                                                                                                                                                                                                                            
  📸 Validation & Logs
  - 236 tests pass, 1 skipped, 0 failures                                                                                                                                                                                                        
  - Pre-commit clean (ruff, ruff-format, codespell, mypy, pylint, detect-secrets, shellcheck)
  - Tested on live HA with real HYXi H5K-HT three-phase hybrid inverter for 2 weeks — results are very promising. Occasional charge/discharge overshoot related to stale cloud data; mitigations are in place and working well.                  
           
  🔗 Traceability                                                                                                                                                                                                                                
  - Relates to: —
  - Closes: —                                                                                                                                                                                                                                    
           
  🔜 Next feature:                                                                                                                                                                                                                               
  As soon as the hyxi-cloud-api merge takes place, I will integrate webhook support for real-time push data — resulting in faster decisions and real-time data instead of relying on cloud polling intervals. Since this requires the HA instance
   to be publicly accessible (not everyone wants that), it will ship as a separate opt-in feature that works in conjunction with the Energy Manager but is not required.  