### PR TITLE
feat: robust VPP lockout, option hiding when active, and entity cleanup

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -135,6 +135,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
     _remove_legacy_select_entities(hass, coordinator.data)
+    _cleanup_control_entities(hass, entry, coordinator)
     await _async_setup_battery_protection(hass, coordinator)
 
     # Energy Manager: create engine if configured and enabled
@@ -205,6 +206,68 @@ def _remove_legacy_select_entities(hass: HomeAssistant, devices: dict) -> None:
             if entity_id is not None:
                 _LOGGER.debug("Removing legacy HYXI select entity %s", entity_id)
                 registry.async_remove(entity_id)
+
+
+def _cleanup_control_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: HyxiDataUpdateCoordinator,
+) -> None:
+    """Remove control entities from registry if battery control is disabled."""
+    from .const import is_battery_control_enabled
+
+    if is_battery_control_enabled(entry, coordinator):
+        return
+
+    _LOGGER.debug(
+        "Battery control is disabled. Cleaning up any registered control entities from registry"
+    )
+    registry = er.async_get(hass)
+    for sn in coordinator.data:
+        # Buttons
+        for key in (
+            "mode_idle",
+            "mode_charge",
+            "mode_discharge",
+            "mode_self_consume",
+            "peak_shaving_close",
+            "peak_shaving_charge",
+            "peak_shaving_discharge",
+            "peak_shaving_stop",
+            "peak_shaving_hold",
+        ):
+            unique_id = f"hyxi_{sn}_{key}"
+            if entity_id := registry.async_get_entity_id("button", DOMAIN, unique_id):
+                _LOGGER.debug("Removing control button entity %s", entity_id)
+                registry.async_remove(entity_id)
+
+        # Switches
+        for key in ("frequency_control", "micro_power"):
+            unique_id = f"hyxi_{sn}_{key}"
+            if entity_id := registry.async_get_entity_id("switch", DOMAIN, unique_id):
+                _LOGGER.debug("Removing control switch entity %s", entity_id)
+                registry.async_remove(entity_id)
+
+        # Numbers
+        for key in (
+            "charge_power",
+            "discharge_power",
+            "soc_min",
+            "soc_max",
+            "soc_min_hysteresis_pct",
+            "soc_max_hysteresis_pct",
+            "micro_power_limit",
+        ):
+            unique_id = f"hyxi_{sn}_{key}"
+            if entity_id := registry.async_get_entity_id("number", DOMAIN, unique_id):
+                _LOGGER.debug("Removing control number entity %s", entity_id)
+                registry.async_remove(entity_id)
+
+        # Sensors
+        unique_id = f"hyxi_{sn}_last_sent_mode"
+        if entity_id := registry.async_get_entity_id("sensor", DOMAIN, unique_id):
+            _LOGGER.debug("Removing control sensor entity %s", entity_id)
+            registry.async_remove(entity_id)
 
 
 async def _async_setup_battery_protection(

--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -17,7 +17,14 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 from hyxi_cloud_api import VPP_ACTIVE_MODES
 
-from .const import CONF_EM_ENABLED, CONF_EM_INVERTER_SN, DOMAIN, MANUFACTURER
+from .const import (
+    CONF_EM_ENABLED,
+    CONF_EM_INVERTER_SN,
+    DOMAIN,
+    MANUFACTURER,
+    get_raw_device_code,
+    normalize_device_type,
+)
 
 ACTIVE_ALARM_STATES = {"0", "1", "2", 0, 1, 2}
 
@@ -37,8 +44,8 @@ async def async_setup_entry(
     for device_sn, dev_data in coordinator.data.items():
         entities.append(HyxiDeviceAlarmSensor(coordinator, entry, device_sn))
 
-        dev_type = (dev_data.get("device_type_code") or "").upper()
-        if dev_type in _VPP_CAPABLE_TYPES:
+        dev_type = normalize_device_type(get_raw_device_code(dev_data))
+        if dev_type in ("hybrid_inverter", "all_in_one", "micro_ess"):
             entities.append(
                 HyxiVppControlSensor(coordinator, entry, device_sn, dev_data)
             )
@@ -245,13 +252,13 @@ class HyxiVppControlSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return True when an active VPP mode is in progress."""
-        return self._metrics.get("vppMode") in VPP_ACTIVE_MODES
+        return str(self._metrics.get("vppMode")) in VPP_ACTIVE_MODES
 
     @property
     def extra_state_attributes(self) -> dict:
         """Expose VPP programme details for dashboard and debugging."""
         m = self._metrics
-        mode = m.get("vppMode") or ""
+        mode = str(m.get("vppMode")) if m.get("vppMode") is not None else ""
         code = m.get("vppCode") or ""
         name = m.get("vppName") or ""
         supplier = m.get("vppSupplierName") or ""
@@ -260,7 +267,7 @@ class HyxiVppControlSensor(CoordinatorEntity, BinarySensorEntity):
         # If VPP is active but details are empty (common via OpenAPI which lacks
         # the app-only vppSupplier endpoint), provide clean fallbacks instead of
         # contradicting "Not enrolled" labels.
-        is_active = mode in VPP_ACTIVE_MODES
+        is_active = str(mode) in VPP_ACTIVE_MODES
         if is_active:
             if not supplier:
                 supplier = "Enrolled (Active VPP)"

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -54,7 +54,7 @@ def _is_vpp_active(coordinator, sn: str) -> bool:
     user commands from conflicting with the active VPP dispatch.
     """
     metrics = (coordinator.data.get(sn) or {}).get("metrics", {})
-    return metrics.get("vppMode") in VPP_ACTIVE_MODES
+    return str(metrics.get("vppMode")) in VPP_ACTIVE_MODES
 
 
 async def async_setup_entry(

--- a/custom_components/hyxi_cloud/config_flow.py
+++ b/custom_components/hyxi_cloud/config_flow.py
@@ -162,10 +162,14 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
             self._options[CONF_BACK_DISCOVERY] = user_input.get(
                 CONF_BACK_DISCOVERY, False
             )
-            self._options["enable_battery_control"] = user_input.get(
-                "enable_battery_control", False
-            )
-            enable_em = user_input.get("enable_energy_manager", False)
+            if "enable_battery_control" in user_input:
+                self._options["enable_battery_control"] = user_input[
+                    "enable_battery_control"
+                ]
+
+            enable_em = self._options.get(CONF_EM_ENABLED, False)
+            if "enable_energy_manager" in user_input:
+                enable_em = user_input["enable_energy_manager"]
 
             # EM requires battery control — auto-enable if user turned on EM
             if enable_em and not self._options.get("enable_battery_control"):
@@ -207,8 +211,8 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
             ): selector.BooleanSelector(),
         }
 
-        # Only show control/EM toggles if controllable inverters exist
-        if has_controllable:
+        # Only show control/EM toggles if controllable inverters exist and VPP is inactive
+        if has_controllable and not self._is_vpp_active():
             battery_control_on = self._config_entry.options.get(
                 "enable_battery_control", False
             )
@@ -346,3 +350,22 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
     def _has_controllable_inverter(self) -> bool:
         """Check if any controllable inverter exists."""
         return len(self._get_controllable_sns()) > 0
+
+    def _is_vpp_active(self) -> bool:
+        """Check if any controllable inverter has an active VPP mode."""
+        coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        if not coordinator or not coordinator.data:
+            return False
+
+        from hyxi_cloud_api import VPP_ACTIVE_MODES
+
+        for sn in self._get_controllable_sns():
+            dev_data = coordinator.data.get(sn) or {}
+            metrics = dev_data.get("metrics", {})
+            vpp_mode = metrics.get("vppMode")
+            work_mode = metrics.get("workMode")
+            if (vpp_mode is not None and str(vpp_mode) in VPP_ACTIVE_MODES) or (
+                work_mode is not None and str(work_mode) in VPP_ACTIVE_MODES
+            ):
+                return True
+        return False

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -183,26 +183,13 @@ def detect_phase_type(dev_data: dict) -> str:
 def is_battery_control_enabled(entry: Any, coordinator: Any) -> bool:
     """Return True if battery control is enabled by user options.
 
-    If not explicitly set in options, defaults to True unless VPP is active.
+    If not explicitly set in options, defaults to False.
     """
     val = entry.options.get("enable_battery_control")
     if val is not None:
         return val
 
-    # Default logic when options not set
-    if coordinator is None:
-        return True
-
-    from hyxi_cloud_api import VPP_ACTIVE_MODES
-
-    for dev_data in coordinator.data.values():
-        metrics = dev_data.get("metrics", {})
-        if (
-            metrics.get("workMode") in VPP_ACTIVE_MODES
-            or metrics.get("vppMode") in VPP_ACTIVE_MODES
-        ):
-            return False
-    return True
+    return False
 
 
 PLATFORMS: list[Platform] = [

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 def _is_vpp_active(coordinator, sn: str) -> bool:
     """Return True if a VPP program is currently controlling this device."""
     metrics = (coordinator.data.get(sn) or {}).get("metrics", {})
-    return metrics.get("vppMode") in VPP_ACTIVE_MODES
+    return str(metrics.get("vppMode")) in VPP_ACTIVE_MODES
 
 
 async def async_setup_entry(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -63,6 +63,7 @@ def mock_ha_environment():
     mock_api = MagicMock()
     mock_api.__name__ = "hyxi_cloud_api"
     mock_api.__version__ = "1.0.4"
+    mock_api.VPP_ACTIVE_MODES = frozenset({"13", "14", "16"})
     sys.modules["hyxi_cloud_api"] = mock_api
     sys.modules["voluptuous"] = mock_ha
 
@@ -436,3 +437,57 @@ async def test_step_user_already_configured(mock_validate_input, config_flow):
 
     config_flow.async_set_unique_id.assert_called_once_with("existing_key")
     config_flow._abort_if_unique_id_configured.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_options_flow_vpp_active_hides_toggles(mock_ha_environment):
+    import custom_components.hyxi_cloud.config_flow as config_flow_mod
+
+    config_entry = MagicMock()
+    config_entry.options = {
+        "update_interval": 10,
+        "enable_battery_control": True,
+        config_flow_mod.CONF_EM_ENABLED: False,
+    }
+
+    options_flow = config_flow_mod.HyxiOptionsFlowHandler(config_entry)
+    options_flow.hass = MagicMock()
+
+    # 1. Setup mock coordinator data with a hybrid inverter
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {
+        "SN123": {
+            "deviceType": "HYBRID_INVERTER",
+            "metrics": {
+                "workMode": "16",  # VPP active
+            },
+        }
+    }
+    options_flow.hass.data = {
+        config_flow_mod.DOMAIN: {config_entry.entry_id: mock_coordinator}
+    }
+
+    # 2. Verify _is_vpp_active returns True
+    assert options_flow._is_vpp_active() is True
+
+    # 3. Verify show_form hides the toggles
+    options_flow.async_show_form = MagicMock(
+        return_value={"type": "form", "step_id": "init"}
+    )
+    result = await options_flow.async_step_init(user_input=None)
+    assert result["type"] == "form"
+
+    # 4. Verify submit preserves hidden toggles
+    options_flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+    # Submit only interval and discovery (battery_control is not in form input because it's hidden)
+    submit_result = await options_flow.async_step_init(
+        user_input={"update_interval": 30, config_flow_mod.CONF_BACK_DISCOVERY: False}
+    )
+    assert submit_result["type"] == "create_entry"
+    call_kwargs = options_flow.async_create_entry.call_args.kwargs
+
+    # Hidden options must be preserved!
+    assert call_kwargs["data"]["update_interval"] == 30
+    assert call_kwargs["data"]["enable_battery_control"] is True
+    assert config_flow_mod.CONF_EM_ENABLED not in call_kwargs["data"]

--- a/tests/test_vpp.py
+++ b/tests/test_vpp.py
@@ -70,11 +70,11 @@ force_mock_attribute(
 
 # Mock hyxi_cloud_api
 mock_api = MagicMock()
-mock_api.VPP_ACTIVE_MODES = frozenset({"16"})
+mock_api.VPP_ACTIVE_MODES = frozenset({"13", "14", "16"})
 if "hyxi_cloud_api" not in sys.modules:
     sys.modules["hyxi_cloud_api"] = mock_api
 else:
-    sys.modules["hyxi_cloud_api"].VPP_ACTIVE_MODES = frozenset({"16"})  # type: ignore[attr-defined]
+    sys.modules["hyxi_cloud_api"].VPP_ACTIVE_MODES = frozenset({"13", "14", "16"})  # type: ignore[attr-defined]
 
 # Import modules and force reload to ensure they use our fakes
 import custom_components.hyxi_cloud.binary_sensor as binary_sensor_mod
@@ -108,7 +108,8 @@ def test_vpp_control_sensor_states():
     entry.entry_id = "test_entry"
 
     with patch(
-        "custom_components.hyxi_cloud.binary_sensor.VPP_ACTIVE_MODES", frozenset({"16"})
+        "custom_components.hyxi_cloud.binary_sensor.VPP_ACTIVE_MODES",
+        frozenset({"13", "14", "16"}),
     ):
         sensor = binary_sensor_mod.HyxiVppControlSensor(coordinator, entry, "SN123", {})
         assert sensor.is_on is True
@@ -119,20 +120,25 @@ def test_vpp_control_sensor_states():
         assert attrs["vpp_manufacturer"] == "HYXI"
         assert attrs["vpp_supplier_name"] == "Supplier"
 
-        # Test fallback behavior when details are empty but VPP is active
-        coordinator.data["SN123"]["metrics"] = {
-            "vppMode": "16",
-            "vppCode": "",
-            "vppName": "",
-            "vppManufacturer": "",
-            "vppSupplierName": "",
-        }
-        attrs = sensor.extra_state_attributes
-        assert attrs["vpp_mode"] == "16"
-        assert attrs["vpp_code"] == "Active"
-        assert attrs["vpp_name"] == "Active VPP"
-        assert attrs["vpp_manufacturer"] == "Enrolled"
-        assert attrs["vpp_supplier_name"] == "Enrolled (Active VPP)"
+        # Test fallback behavior when details are empty but VPP is active (using integer mode 13/14/16)
+        for active_mode in (13, 14, 16):
+            coordinator.data["SN123"]["metrics"] = {
+                "vppMode": active_mode,
+                "vppCode": "",
+                "vppName": "",
+                "vppManufacturer": "",
+                "vppSupplierName": "",
+            }
+            sensor_int = binary_sensor_mod.HyxiVppControlSensor(
+                coordinator, entry, "SN123", {}
+            )
+            assert sensor_int.is_on is True
+            attrs = sensor_int.extra_state_attributes
+            assert attrs["vpp_mode"] == str(active_mode)
+            assert attrs["vpp_code"] == "Active"
+            assert attrs["vpp_name"] == "Active VPP"
+            assert attrs["vpp_manufacturer"] == "Enrolled"
+            assert attrs["vpp_supplier_name"] == "Enrolled (Active VPP)"
 
         # Test inactive VPP
         coordinator.data["SN123"]["metrics"] = {
@@ -161,19 +167,19 @@ def test_is_battery_control_enabled_helper():
     entry.options = {"enable_battery_control": False}
     assert is_battery_control_enabled(entry, None) is False
 
-    # Case 2: Not set, no active VPP
+    # Case 2: Not set, no active VPP (should default to False)
     entry.options = {}
     coordinator = MagicMock()
     coordinator.data = {"SN123": {"metrics": {"workMode": "0"}}}
     with patch("hyxi_cloud_api.VPP_ACTIVE_MODES", frozenset({"16"})):
-        assert is_battery_control_enabled(entry, coordinator) is True
+        assert is_battery_control_enabled(entry, coordinator) is False
 
-        # Case 3: Not set, active VPP
+        # Case 3: Not set, active VPP (should still default to False)
         coordinator.data["SN123"]["metrics"]["workMode"] = "16"
         assert is_battery_control_enabled(entry, coordinator) is False
 
         # Case 4: Coordinator is None
-        assert is_battery_control_enabled(entry, None) is True
+        assert is_battery_control_enabled(entry, None) is False
 
 
 def test_button_and_switch_lockout():
@@ -184,22 +190,27 @@ def test_button_and_switch_lockout():
 
     with (
         patch(
-            "custom_components.hyxi_cloud.button.VPP_ACTIVE_MODES", frozenset({"16"})
+            "custom_components.hyxi_cloud.button.VPP_ACTIVE_MODES",
+            frozenset({"13", "14", "16"}),
         ),
         patch(
-            "custom_components.hyxi_cloud.switch.VPP_ACTIVE_MODES", frozenset({"16"})
+            "custom_components.hyxi_cloud.switch.VPP_ACTIVE_MODES",
+            frozenset({"13", "14", "16"}),
         ),
     ):
-        # Button lockout
-        btn = button_mod.HyxiModeButton(coordinator, "SN123", {}, "idle")
+        for active_mode in (13, 14, 16):
+            # Button lockout (with integer and string modes)
+            coordinator.data["SN123"]["metrics"]["vppMode"] = active_mode
+            btn = button_mod.HyxiModeButton(coordinator, "SN123", {}, "idle")
+            assert btn.available is False
 
-        assert btn.available is False
-
-        # Switch lockout
-        sw = switch_mod.HyxiFrequencyControlSwitch(coordinator, "SN123", {})
-        assert sw.available is False
+            # Switch lockout
+            sw = switch_mod.HyxiFrequencyControlSwitch(coordinator, "SN123", {})
+            assert sw.available is False
 
         # Inactive VPP controls are available
-        coordinator.data["SN123"]["metrics"]["vppMode"] = "0"
+        coordinator.data["SN123"]["metrics"]["vppMode"] = 0
+        btn = button_mod.HyxiModeButton(coordinator, "SN123", {}, "idle")
+        sw = switch_mod.HyxiFrequencyControlSwitch(coordinator, "SN123", {})
         assert btn.available is True
         assert sw.available is True


### PR DESCRIPTION
# Summary
This Pull Request implements robust support for Virtual Power Plant (VPP) active modes (including modes `13` VPP Charge and `14` VPP Discharge), dynamically hides battery control configuration options when VPP is active, and performs active cleanup of registered HA entities when battery control is disabled.

# Key Changes
* **Registry Entity Cleanup (`__init__.py`)**: Implemented `_cleanup_control_entities` to actively purge registered buttons, switches, numbers, and last sent mode sensors from the HA Entity Registry when "Enable Device Control & Protection" is disabled.
* **VPP Device/Type Support (`binary_sensor.py`)**: Used normalized device types to ensure VPP sensors set up correctly on real inverters (which use numeric device type codes). Cast `vppMode` to string to prevent comparison failures when the API returns integers.
* **VPP Lockouts (`button.py`, `switch.py`)**: Cast `vppMode` to string to ensure lockout checks properly engage for modes `13`, `14`, and `16`.
* **Config Flow Hiding (`config_flow.py`)**: Dynamically hide battery control and energy manager checkboxes from the options flow UI if VPP is currently active on any controllable inverter, preserving their existing settings upon submission.
* **Option Defaults (`const.py`)**: Set default behavior of `enable_battery_control` to `False` (disabled by default) when not explicitly set.
* **Unit Tests (`tests/test_vpp.py`, `tests/test_config_flow.py`)**: Added test coverage validating VPP modes `13`, `14`, and `16` lockout/sensor states, option flow hiding, and settings preservation.

# Why this is needed
Ensures that the integration is production-grade and secure when working with dynamic VPP smart charging providers (like Frank Energie). It prevents local HA controls from conflicting with VPP charging/discharging schedules by locking them out and hiding options during active dispatch periods. Additionally, it guarantees a clean UI and Entity Registry when a user decides to disable device controls.