### PR TITLE
chore: bump hyxi-cloud-api requirement to 1.2.8

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -14,7 +14,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.7"
+    "hyxi-cloud-api>=1.2.8"
   ],
   "version": "1.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.2.7"
+    "hyxi-cloud-api>=1.2.8"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.7
+hyxi-cloud-api>=1.2.8
 
 # Development/Linting tools
 ruff>=0.15.14

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.152.9
-hyxi-cloud-api>=1.2.7
+hyxi-cloud-api>=1.2.8
 pytest-homeassistant-custom-component>=0.13.333


### PR DESCRIPTION
# Summary
This Pull Request bumps the required version of `hyxi-cloud-api` to `>=1.2.8`.

# Key Changes
* Bumped `hyxi-cloud-api` to `>=1.2.8` in `requirements_test.txt`.
* Bumped `hyxi-cloud-api` to `>=1.2.8` in `custom_components/hyxi_cloud/manifest.json`.
* Bumped `hyxi-cloud-api` to `>=1.2.8` in `pyproject.toml`.
* Bumped `hyxi-cloud-api` to `>=1.2.8` in `requirements.txt`.

# Why this is needed
Allows the Home Assistant integration to pull the new version `1.2.8` of the API client package (which includes the VPP charge/discharge active mode expansions) during setup and automated testing.