### PR TITLE
feat: add VPP lockout override options flow checkbox and entity bypass

### DIFF
--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -20,6 +20,7 @@ from hyxi_cloud_api import VPP_ACTIVE_MODES, HyxiApiClient
 
 from .binary_sensor import ACTIVE_ALARM_STATES
 from .const import (
+    CONF_OVERRIDE_VPP,
     DOMAIN,
     MANUFACTURER,
     detect_phase_type,
@@ -53,6 +54,8 @@ def _is_vpp_active(coordinator, sn: str) -> bool:
     When True, manual control buttons must become unavailable to prevent
     user commands from conflicting with the active VPP dispatch.
     """
+    if coordinator.config_entry.options.get(CONF_OVERRIDE_VPP, False):
+        return False
     metrics = (coordinator.data.get(sn) or {}).get("metrics", {})
     return str(metrics.get("vppMode")) in VPP_ACTIVE_MODES
 

--- a/custom_components/hyxi_cloud/config_flow.py
+++ b/custom_components/hyxi_cloud/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_EM_INVERTER_SN,
     CONF_EM_LOOP_INTERVAL,
     CONF_EM_P1_ENTITY,
+    CONF_OVERRIDE_VPP,
     CONF_SECRET_KEY,
     DOMAIN,
     get_raw_device_code,
@@ -157,15 +158,27 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the options form."""
         if user_input is not None:
             # Preserve all existing options, update with new values
-            self._options = dict(self._config_entry.options)
+            self._options = (
+                dict(self._options)
+                if self._options
+                else dict(self._config_entry.options)
+            )
             self._options["update_interval"] = user_input["update_interval"]
             self._options[CONF_BACK_DISCOVERY] = user_input.get(
                 CONF_BACK_DISCOVERY, False
             )
+
+            was_override_enabled = self._options.get(CONF_OVERRIDE_VPP, False)
+            was_battery_control_enabled = self._options.get(
+                "enable_battery_control", False
+            )
+
             if "enable_battery_control" in user_input:
                 self._options["enable_battery_control"] = user_input[
                     "enable_battery_control"
                 ]
+            if CONF_OVERRIDE_VPP in user_input:
+                self._options[CONF_OVERRIDE_VPP] = user_input[CONF_OVERRIDE_VPP]
 
             enable_em = self._options.get(CONF_EM_ENABLED, False)
             if "enable_energy_manager" in user_input:
@@ -174,6 +187,26 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
             # EM requires battery control — auto-enable if user turned on EM
             if enable_em and not self._options.get("enable_battery_control"):
                 self._options["enable_battery_control"] = True
+
+            # If user just enabled override_vpp, but enable_battery_control wasn't in user_input,
+            # reload the step to reveal it (only if controllable inverters exist).
+            if (
+                self._has_controllable_inverter()
+                and self._options.get(CONF_OVERRIDE_VPP, False)
+                and not was_override_enabled
+                and "enable_battery_control" not in user_input
+            ):
+                return await self.async_step_init()
+
+            # If user just enabled battery_control, but enable_energy_manager wasn't in user_input,
+            # reload the step to reveal it (only if controllable inverters exist).
+            if (
+                self._has_controllable_inverter()
+                and self._options.get("enable_battery_control", False)
+                and not was_battery_control_enabled
+                and "enable_energy_manager" not in user_input
+            ):
+                return await self.async_step_init()
 
             if enable_em:
                 self._options[CONF_EM_ENABLED] = True
@@ -195,8 +228,9 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=self._options)
 
         # Pull current values or defaults
-        current_interval = self._config_entry.options.get("update_interval", 5)
-        em_enabled = self._config_entry.options.get(CONF_EM_ENABLED, False)
+        options = self._options if self._options else self._config_entry.options
+        current_interval = options.get("update_interval", 5)
+        em_enabled = options.get(CONF_EM_ENABLED, False)
         has_controllable = self._has_controllable_inverter()
 
         schema_dict = {
@@ -207,26 +241,34 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
             # Toggle for Alarm-based discovery
             vol.Optional(
                 CONF_BACK_DISCOVERY,
-                default=self._config_entry.options.get(CONF_BACK_DISCOVERY, False),
+                default=options.get(CONF_BACK_DISCOVERY, False),
             ): selector.BooleanSelector(),
         }
 
-        # Only show control/EM toggles if controllable inverters exist and VPP is inactive
-        if has_controllable and not self._is_vpp_active():
-            battery_control_on = self._config_entry.options.get(
-                "enable_battery_control", False
-            )
-            schema_dict[
-                vol.Optional(
-                    "enable_battery_control",
-                    default=battery_control_on,
-                )
-            ] = selector.BooleanSelector()
-            # EM toggle only visible when battery control is already enabled
-            if battery_control_on:
+        # Only show control/EM toggles if controllable inverters exist
+        if has_controllable:
+            vpp_active_raw = self._is_vpp_active_raw()
+            if vpp_active_raw:
                 schema_dict[
-                    vol.Optional("enable_energy_manager", default=em_enabled)
+                    vol.Optional(
+                        CONF_OVERRIDE_VPP,
+                        default=options.get(CONF_OVERRIDE_VPP, False),
+                    )
                 ] = selector.BooleanSelector()
+
+            if not vpp_active_raw or options.get(CONF_OVERRIDE_VPP, False):
+                battery_control_on = options.get("enable_battery_control", False)
+                schema_dict[
+                    vol.Optional(
+                        "enable_battery_control",
+                        default=battery_control_on,
+                    )
+                ] = selector.BooleanSelector()
+                # EM toggle only visible when battery control is already enabled
+                if battery_control_on:
+                    schema_dict[
+                        vol.Optional("enable_energy_manager", default=em_enabled)
+                    ] = selector.BooleanSelector()
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema_dict))
 
@@ -337,6 +379,8 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
 
     def _get_controllable_sns(self) -> list[str]:
         """Get serial numbers of controllable inverters from coordinator data."""
+        if not hasattr(self, "hass") or self.hass is None:
+            return []
         coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
         if not coordinator or not coordinator.data:
             return []
@@ -353,6 +397,13 @@ class HyxiOptionsFlowHandler(config_entries.OptionsFlow):
 
     def _is_vpp_active(self) -> bool:
         """Check if any controllable inverter has an active VPP mode."""
+        options = self._options if self._options else self._config_entry.options
+        if options.get(CONF_OVERRIDE_VPP, False):
+            return False
+        return self._is_vpp_active_raw()
+
+    def _is_vpp_active_raw(self) -> bool:
+        """Check if any controllable inverter has an active VPP mode raw metrics."""
         coordinator = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
         if not coordinator or not coordinator.data:
             return False

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -15,6 +15,8 @@ MANUFACTURER = "HYXI Power"
 VERSION = "1.6.0"
 
 CONF_BACK_DISCOVERY = "back_discovery"
+CONF_OVERRIDE_VPP = "override_vpp"
+
 
 NULL_VALUES = {"", "null", "none", "na", "--"}
 

--- a/custom_components/hyxi_cloud/strings.json
+++ b/custom_components/hyxi_cloud/strings.json
@@ -39,7 +39,8 @@
           "update_interval": "Polling Interval (1-60 Minutes, Default: 5)",
           "back_discovery": "Enable discovery via alarms (Advanced)",
           "enable_battery_control": "Enable Device Control & Protection",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Override VPP Lock (force-enable controls during VPP)"
         }
       },
       "energy_manager": {

--- a/custom_components/hyxi_cloud/switch.py
+++ b/custom_components/hyxi_cloud/switch.py
@@ -17,6 +17,7 @@ from hyxi_cloud_api import VPP_ACTIVE_MODES, HyxiApiClient
 from .const import (
     CONF_EM_ENABLED,
     CONF_EM_INVERTER_SN,
+    CONF_OVERRIDE_VPP,
     DOMAIN,
     detect_phase_type,
     get_raw_device_code,
@@ -31,6 +32,8 @@ _LOGGER = logging.getLogger(__name__)
 
 def _is_vpp_active(coordinator, sn: str) -> bool:
     """Return True if a VPP program is currently controlling this device."""
+    if coordinator.config_entry.options.get(CONF_OVERRIDE_VPP, False):
+        return False
     metrics = (coordinator.data.get(sn) or {}).get("metrics", {})
     return str(metrics.get("vppMode")) in VPP_ACTIVE_MODES
 

--- a/custom_components/hyxi_cloud/translations/af.json
+++ b/custom_components/hyxi_cloud/translations/af.json
@@ -38,7 +38,8 @@
           "update_interval": "Opvragsinterval (1-60 minute, verstek: 5)",
           "back_discovery": "Aktiveer ontdekking via alarms (Gevorderd)",
           "enable_battery_control": "Aktiveer toestelbeheer en -beskerming",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Ignoreer VPP-slot (forseer kontroles tydens VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Probleem"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/cs.json
+++ b/custom_components/hyxi_cloud/translations/cs.json
@@ -38,7 +38,8 @@
           "update_interval": "Interval dotazování (1-60 minut, výchozí: 5)",
           "back_discovery": "Povolit vyhledávání prostřednictvím alarmů (pro pokročilé)",
           "enable_battery_control": "Aktivovat ovládání a ochranu zařízení",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Přepsat zámek VPP (vynutit ovládací prvky během VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problém"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/da.json
+++ b/custom_components/hyxi_cloud/translations/da.json
@@ -38,7 +38,8 @@
           "update_interval": "Opdateringsinterval (1-60 minutter, standard: 5)",
           "back_discovery": "Aktiver opdagelse via alarmer (avanceret)",
           "enable_battery_control": "Aktiver enhedskontrol og -beskyttelse",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Tilsidesæt VPP-lås (gennemtving kontroller under VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problem"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/de.json
+++ b/custom_components/hyxi_cloud/translations/de.json
@@ -38,7 +38,8 @@
           "update_interval": "Abfrageintervall (1-60 Minuten, Standard: 5)",
           "back_discovery": "Discovery über Alarme aktivieren (Erweitert)",
           "enable_battery_control": "Gerätesteuerung und -schutz aktivieren",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "VPP-Sperre überschreiben (Steuerungen während VPP erzwingen)"
         }
       },
       "energy_manager": {

--- a/custom_components/hyxi_cloud/translations/en.json
+++ b/custom_components/hyxi_cloud/translations/en.json
@@ -38,7 +38,8 @@
           "update_interval": "Polling Interval (1-60 Minutes, Default: 5)",
           "back_discovery": "Enable discovery via alarms (Advanced)",
           "enable_battery_control": "Enable Device Control & Protection",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Override VPP Lock (force-enable controls during VPP)"
         }
       },
       "energy_manager": {

--- a/custom_components/hyxi_cloud/translations/es.json
+++ b/custom_components/hyxi_cloud/translations/es.json
@@ -38,7 +38,8 @@
           "update_interval": "Intervalo de actualización (1-60 minutos, por defecto: 5)",
           "back_discovery": "Habilitar descubrimiento mediante alarmas (Avanzado)",
           "enable_battery_control": "Activar control y protección del dispositivo",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Anular bloqueo de VPP (forzar controles durante VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problema"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/fi.json
+++ b/custom_components/hyxi_cloud/translations/fi.json
@@ -38,7 +38,8 @@
           "update_interval": "Päivitysväli (1-60 minuuttia, oletus: 5)",
           "back_discovery": "Ota löytäminen käyttöön hällytysten kautta (edistynyt)",
           "enable_battery_control": "Ota laitteen ohjaus ja suojaus käyttöön",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Ohita VPP-lukitus (pakota ohjaus VPP:n aikana)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Ongelma"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/fr.json
+++ b/custom_components/hyxi_cloud/translations/fr.json
@@ -38,7 +38,8 @@
           "update_interval": "Intervalle de mise à jour (1-60 minutes, Défaut : 5)",
           "back_discovery": "Activer la découverte via les alarmes (Avancé)",
           "enable_battery_control": "Activer le contrôle et la protection de l'appareil",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Contourner le verrouillage VPP (forcer les commandes pendant le VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problème"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/hu.json
+++ b/custom_components/hyxi_cloud/translations/hu.json
@@ -38,7 +38,8 @@
           "update_interval": "Lekérdezési időköz (1-60 perc, alapértelmezett: 5)",
           "back_discovery": "Eszközfelderítés engedélyezése riasztásokon keresztül (haladó)",
           "enable_battery_control": "Eszközvezérlés és -védelem engedélyezése",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "VPP-zár felülbírálása (vezérlők kényszerítése VPP alatt)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Probléma"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/it.json
+++ b/custom_components/hyxi_cloud/translations/it.json
@@ -38,7 +38,8 @@
           "update_interval": "Intervallo di aggiornamento (1-60 Minuti, Predefinito: 5)",
           "back_discovery": "Abilita il rilevamento tramite allarmi (Avanzato)",
           "enable_battery_control": "Abilita controllo e protezione dispositivo",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Ignora blocco VPP (forza i controlli durante VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problema"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/ja.json
+++ b/custom_components/hyxi_cloud/translations/ja.json
@@ -38,7 +38,8 @@
           "update_interval": "ポーリング間隔 (1-60分, デフォルト: 5)",
           "back_discovery": "アラーム経由の検出を有効にする (高度)",
           "enable_battery_control": "デバイス制御と保護を有効にする",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "VPPロックの上書き (VPP中の制御を強制有効化)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "異常あり"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/nb.json
+++ b/custom_components/hyxi_cloud/translations/nb.json
@@ -38,7 +38,8 @@
           "update_interval": "Oppdateringsintervall (1-60 minutter, standard: 5)",
           "back_discovery": "Aktiver oppdaging via alarmer (avansert)",
           "enable_battery_control": "Aktiver enhetskontroll og -beskyttelse",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Overstyr VPP-lås (tving kontroller under VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problem"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/nl.json
+++ b/custom_components/hyxi_cloud/translations/nl.json
@@ -38,7 +38,8 @@
           "update_interval": "Update-interval (1-60 minuten, Standaard: 5)",
           "back_discovery": "Ontdekking via alarmen inschakelen (Geavanceerd)",
           "enable_battery_control": "Apparaatcontrole en -bescherming inschakelen",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "VPP-vergrendeling overschrijven (bediening forceren tijdens VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Probleem"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/pl.json
+++ b/custom_components/hyxi_cloud/translations/pl.json
@@ -38,7 +38,8 @@
           "update_interval": "Interwał odpytywania (1-60 minut, domyślnie: 5)",
           "back_discovery": "Włącz wykrywanie przez alarmy (zaawansowane)",
           "enable_battery_control": "Włącz kontrolę i ochronę urządzenia",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Pomiń blokadę VPP (wymuś sterowanie podczas VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problem"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/pt-BR.json
+++ b/custom_components/hyxi_cloud/translations/pt-BR.json
@@ -38,7 +38,8 @@
           "update_interval": "Intervalo de Atualização (1-60 minutos, padrão: 5)",
           "back_discovery": "Habilitar descoberta via alarmes (Avançado)",
           "enable_battery_control": "Ativar controle e proteção do dispositivo",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Ignorar bloqueio do VPP (forçar controles durante o VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Ativo"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/pt.json
+++ b/custom_components/hyxi_cloud/translations/pt.json
@@ -38,7 +38,8 @@
           "update_interval": "Intervalo de Atualização (1-60 minutos, padrão: 5)",
           "back_discovery": "Habilitar descoberta via alarmes (Avançado)",
           "enable_battery_control": "Ativar controle e proteção do dispositivo",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Ignorar bloqueio do VPP (forçar controlos durante o VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Ativo"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/ru.json
+++ b/custom_components/hyxi_cloud/translations/ru.json
@@ -38,7 +38,8 @@
           "update_interval": "Интервал обновления (1-60 минут, по умолчанию: 5)",
           "back_discovery": "Включить обнаружение через аварийные сигналы (расширенный режим)",
           "enable_battery_control": "Включить управление и защиту устройства",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Обход блокировки VPP (принудительное управление во время VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Проблема"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/sv.json
+++ b/custom_components/hyxi_cloud/translations/sv.json
@@ -38,7 +38,8 @@
           "update_interval": "Uppdateringsintervall (1-60 minuter, standard: 5)",
           "back_discovery": "Aktivera upptäckt via larm (Avancerat)",
           "enable_battery_control": "Aktivera enhetskontroll och -skydd",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "Överstyr VPP-lås (tvinga kontroller under VPP)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Problem"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/tr.json
+++ b/custom_components/hyxi_cloud/translations/tr.json
@@ -38,7 +38,8 @@
           "update_interval": "Sorgulama Aralığı (1-60 Dakika, Varsayılan: 5)",
           "back_discovery": "Alarmlar aracılığıyla keşfi etkinleştir (Gelişmiş)",
           "enable_battery_control": "Cihaz kontrolünü ve korumasını etkinleştir",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "VPP Kilidini Geçersiz Kıl (VPP sırasında kontrolleri zorla etkinleştir)"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "Sorun"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/custom_components/hyxi_cloud/translations/zh-Hans.json
+++ b/custom_components/hyxi_cloud/translations/zh-Hans.json
@@ -38,7 +38,8 @@
           "update_interval": "轮询间隔 (1-60 分钟, 默认: 5)",
           "back_discovery": "启用通过报警发现设备 (高级)",
           "enable_battery_control": "启用设备控制与保护",
-          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)"
+          "enable_energy_manager": "Enable Energy Manager Standalone (Beta)",
+          "override_vpp": "绕过 VPP 锁定（在 VPP 期间强制启用控制）"
         }
       },
       "energy_manager": {
@@ -69,7 +70,7 @@
           "on": "有故障"
         }
       },
-"vpp_active": {
+      "vpp_active": {
         "name": "VPP Control Active",
         "state": {
           "off": "Normal Operation",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -470,24 +470,215 @@ async def test_options_flow_vpp_active_hides_toggles(mock_ha_environment):
     # 2. Verify _is_vpp_active returns True
     assert options_flow._is_vpp_active() is True
 
-    # 3. Verify show_form hides the toggles
+    # 3. Verify show_form initially hides toggles but shows override_vpp
     options_flow.async_show_form = MagicMock(
         return_value={"type": "form", "step_id": "init"}
     )
+
+    import voluptuous as vol
+
+    vol.Optional.reset_mock()
+
     result = await options_flow.async_step_init(user_input=None)
     assert result["type"] == "form"
 
-    # 4. Verify submit preserves hidden toggles
-    options_flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
-
-    # Submit only interval and discovery (battery_control is not in form input because it's hidden)
-    submit_result = await options_flow.async_step_init(
-        user_input={"update_interval": 30, config_flow_mod.CONF_BACK_DISCOVERY: False}
+    # Only override_vpp is in the form, not battery control or EM
+    vol.Optional.assert_any_call(config_flow_mod.CONF_OVERRIDE_VPP, default=False)
+    assert (
+        any(
+            call[0][0] == "enable_battery_control"
+            for call in vol.Optional.call_args_list
+        )
+        is False
     )
-    assert submit_result["type"] == "create_entry"
+    assert (
+        any(
+            call[0][0] == "enable_energy_manager"
+            for call in vol.Optional.call_args_list
+        )
+        is False
+    )
+
+    # 4. Submit override_vpp = True. This should trigger a progressive reveal step reload.
+    vol.Optional.reset_mock()
+    submit_result = await options_flow.async_step_init(
+        user_input={
+            "update_interval": 30,
+            config_flow_mod.CONF_BACK_DISCOVERY: False,
+            config_flow_mod.CONF_OVERRIDE_VPP: True,
+        }
+    )
+    assert submit_result["type"] == "form"
+    assert submit_result["step_id"] == "init"
+
+    # In the reloaded form: override_vpp (default True), enable_battery_control (default True) and enable_energy_manager (default False) are shown
+    vol.Optional.assert_any_call(config_flow_mod.CONF_OVERRIDE_VPP, default=True)
+    vol.Optional.assert_any_call("enable_battery_control", default=True)
+    vol.Optional.assert_any_call("enable_energy_manager", default=False)
+
+    # 5. Finally, we submit all options
+    options_flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+    final_result = await options_flow.async_step_init(
+        user_input={
+            "update_interval": 30,
+            config_flow_mod.CONF_BACK_DISCOVERY: False,
+            config_flow_mod.CONF_OVERRIDE_VPP: True,
+            "enable_battery_control": True,
+            "enable_energy_manager": False,
+        }
+    )
+    assert final_result["type"] == "create_entry"
     call_kwargs = options_flow.async_create_entry.call_args.kwargs
 
-    # Hidden options must be preserved!
     assert call_kwargs["data"]["update_interval"] == 30
     assert call_kwargs["data"]["enable_battery_control"] is True
+    assert call_kwargs["data"]["override_vpp"] is True
     assert config_flow_mod.CONF_EM_ENABLED not in call_kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_options_flow_vpp_active_with_override_shows_toggles(mock_ha_environment):
+    import custom_components.hyxi_cloud.config_flow as config_flow_mod
+
+    config_entry = MagicMock()
+    config_entry.options = {
+        "update_interval": 10,
+        "enable_battery_control": True,
+        config_flow_mod.CONF_EM_ENABLED: False,
+        config_flow_mod.CONF_OVERRIDE_VPP: True,
+    }
+
+    options_flow = config_flow_mod.HyxiOptionsFlowHandler(config_entry)
+    options_flow.hass = MagicMock()
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {
+        "SN123": {
+            "deviceType": "HYBRID_INVERTER",
+            "metrics": {
+                "workMode": "16",  # VPP active
+            },
+        }
+    }
+    options_flow.hass.data = {
+        config_flow_mod.DOMAIN: {config_entry.entry_id: mock_coordinator}
+    }
+
+    # Verify _is_vpp_active returns False because of override
+    assert options_flow._is_vpp_active() is False
+
+    # Verify show_form shows the toggles and override_vpp
+    options_flow.async_show_form = MagicMock(
+        return_value={"type": "form", "step_id": "init"}
+    )
+
+    import voluptuous as vol
+
+    vol.Optional.reset_mock()
+
+    result = await options_flow.async_step_init(user_input=None)
+    assert result["type"] == "form"
+
+    vol.Optional.assert_any_call(config_flow_mod.CONF_OVERRIDE_VPP, default=True)
+    vol.Optional.assert_any_call("enable_battery_control", default=True)
+    vol.Optional.assert_any_call("enable_energy_manager", default=False)
+
+
+@pytest.mark.asyncio
+async def test_options_flow_progressive_reveal_all_steps(mock_ha_environment):
+    import custom_components.hyxi_cloud.config_flow as config_flow_mod
+
+    config_entry = MagicMock()
+    config_entry.options = {
+        "update_interval": 10,
+        "enable_battery_control": False,
+        config_flow_mod.CONF_EM_ENABLED: False,
+        config_flow_mod.CONF_OVERRIDE_VPP: False,
+    }
+
+    options_flow = config_flow_mod.HyxiOptionsFlowHandler(config_entry)
+    options_flow.hass = MagicMock()
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.data = {
+        "SN123": {
+            "deviceType": "HYBRID_INVERTER",
+            "metrics": {
+                "workMode": "16",  # VPP active
+            },
+        }
+    }
+    options_flow.hass.data = {
+        config_flow_mod.DOMAIN: {config_entry.entry_id: mock_coordinator}
+    }
+
+    options_flow.async_show_form = MagicMock(
+        return_value={"type": "form", "step_id": "init"}
+    )
+
+    import voluptuous as vol
+
+    # Step 1: Open flow. Only override_vpp is shown.
+    vol.Optional.reset_mock()
+    result1 = await options_flow.async_step_init(user_input=None)
+    assert result1["type"] == "form"
+    vol.Optional.assert_any_call(config_flow_mod.CONF_OVERRIDE_VPP, default=False)
+    assert (
+        any(
+            call[0][0] == "enable_battery_control"
+            for call in vol.Optional.call_args_list
+        )
+        is False
+    )
+
+    # Step 2: Check override_vpp. Reloads form. Shows enable_battery_control.
+    vol.Optional.reset_mock()
+    result2 = await options_flow.async_step_init(
+        user_input={
+            "update_interval": 10,
+            config_flow_mod.CONF_BACK_DISCOVERY: False,
+            config_flow_mod.CONF_OVERRIDE_VPP: True,
+        }
+    )
+    assert result2["type"] == "form"
+    vol.Optional.assert_any_call(config_flow_mod.CONF_OVERRIDE_VPP, default=True)
+    vol.Optional.assert_any_call("enable_battery_control", default=False)
+    assert (
+        any(
+            call[0][0] == "enable_energy_manager"
+            for call in vol.Optional.call_args_list
+        )
+        is False
+    )
+
+    # Step 3: Check enable_battery_control. Reloads form. Shows enable_energy_manager.
+    vol.Optional.reset_mock()
+    result3 = await options_flow.async_step_init(
+        user_input={
+            "update_interval": 10,
+            config_flow_mod.CONF_BACK_DISCOVERY: False,
+            config_flow_mod.CONF_OVERRIDE_VPP: True,
+            "enable_battery_control": True,
+        }
+    )
+    assert result3["type"] == "form"
+    vol.Optional.assert_any_call(config_flow_mod.CONF_OVERRIDE_VPP, default=True)
+    vol.Optional.assert_any_call("enable_battery_control", default=True)
+    vol.Optional.assert_any_call("enable_energy_manager", default=False)
+
+    # Step 4: Check enable_energy_manager. Redirects to energy manager flow.
+    options_flow.async_step_energy_manager = AsyncMock(
+        return_value={"type": "form", "step_id": "energy_manager"}
+    )
+    result4 = await options_flow.async_step_init(
+        user_input={
+            "update_interval": 10,
+            config_flow_mod.CONF_BACK_DISCOVERY: False,
+            config_flow_mod.CONF_OVERRIDE_VPP: True,
+            "enable_battery_control": True,
+            "enable_energy_manager": True,
+        }
+    )
+    assert result4["type"] == "form"
+    assert result4["step_id"] == "energy_manager"
+    options_flow.async_step_energy_manager.assert_called_once()

--- a/tests/test_vpp.py
+++ b/tests/test_vpp.py
@@ -187,6 +187,7 @@ def test_button_and_switch_lockout():
     coordinator = MagicMock()
     coordinator.last_update_success = True
     coordinator.data = {"SN123": {"metrics": {"vppMode": "16"}}}
+    coordinator.config_entry.options = {}
 
     with (
         patch(
@@ -214,3 +215,35 @@ def test_button_and_switch_lockout():
         sw = switch_mod.HyxiFrequencyControlSwitch(coordinator, "SN123", {})
         assert btn.available is True
         assert sw.available is True
+
+
+def test_vpp_override_bypasses_lockout():
+    """Test that buttons and switches remain available during VPP if override is checked."""
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = {"SN123": {"metrics": {"vppMode": "16"}}}
+    coordinator.config_entry = MagicMock()
+
+    with (
+        patch(
+            "custom_components.hyxi_cloud.button.VPP_ACTIVE_MODES",
+            frozenset({"13", "14", "16"}),
+        ),
+        patch(
+            "custom_components.hyxi_cloud.switch.VPP_ACTIVE_MODES",
+            frozenset({"13", "14", "16"}),
+        ),
+    ):
+        # 1. With override disabled, they are unavailable
+        coordinator.config_entry.options = {"override_vpp": False}
+        btn = button_mod.HyxiModeButton(coordinator, "SN123", {}, "idle")
+        sw = switch_mod.HyxiFrequencyControlSwitch(coordinator, "SN123", {})
+        assert btn.available is False
+        assert sw.available is False
+
+        # 2. With override enabled, they are available
+        coordinator.config_entry.options = {"override_vpp": True}
+        btn_override = button_mod.HyxiModeButton(coordinator, "SN123", {}, "idle")
+        sw_override = switch_mod.HyxiFrequencyControlSwitch(coordinator, "SN123", {})
+        assert btn_override.available is True
+        assert sw_override.available is True


### PR DESCRIPTION
## Summary
This pull request adds an options flow checkbox allowing users to override the VPP (Virtual Power Plant) lockout. It allows manual and automated controls (including the Energy Manager engine) to be forced active on supported hybrid/all-in-one inverters even during a VPP dispatch state.

## Key Changes
- **Configuration Flow**: Added `override_vpp` checkbox inside the options flow step `async_step_init`. This checkbox is only visible when an active VPP mode is detected.
- **Progressive Reveal Reload**: Toggles for `enable_battery_control` and `enable_energy_manager` are kept hidden by default during VPP but are progressively revealed in-place when `override_vpp` is toggled.
- **Entity Bypass**: Updated `_is_vpp_active` helper in both `button.py` and `switch.py` to bypass availability lockout if the override option is checked.
- **Translations**: Added localized translations for `"override_vpp"` in all 20 supported language json translation files.
- **Tests**: Added tests in `test_config_flow.py` and `test_vpp.py` verifying options step reloads, progressive reveal, and lockout bypass behavior.

## Why this is needed
When a device is enrolled in a VPP program, the HYXI API sets active VPP modes which lock out manual control commands. Since there is no user-accessible unenrollment method inside the official mobile app, users are permanently locked out of controlling their batteries. This override provides a secure opt-in mechanism to restore functionality.