### PR TITLE
chore: bump hyxi-cloud-api to 1.3.0

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -15,7 +15,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.2.8"
+    "hyxi-cloud-api>=1.3.0"
   ],
   "version": "1.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.2.8"
+    "hyxi-cloud-api>=1.3.0"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.2.8
+hyxi-cloud-api>=1.3.0
 
 # Development/Linting tools
 ruff>=0.15.15

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.155.1
-hyxi-cloud-api>=1.2.8
+hyxi-cloud-api>=1.3.0
 pytest-homeassistant-custom-component>=0.13.334


### PR DESCRIPTION
# Summary
This Pull Request updates the integration's dependency constraint to require `hyxi-cloud-api>=1.3.0`.

# Key Changes
- Bumped `hyxi-cloud-api` version constraint from `>=1.2.8` to `>=1.3.0` in the following files:
  - `custom_components/hyxi_cloud/manifest.json`
  - `pyproject.toml`
  - `requirements.txt`
  - `requirements_test.txt`

# Why this is needed
Aligns the integration with the new `v1.3.0` release of `hyxi-cloud-api`, which contains the new webhook-based real-time data and alarm push parsing APIs.