### PR TITLE
fix: resolve Nabu Casa cloudhook URL correctly and fix mock types under test

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -327,16 +327,23 @@ async def _async_resolve_webhook_url(
     resolved = None
 
     # Check Nabu Casa first
-    from homeassistant.components import cloud
+    import homeassistant.components.cloud as cloud  # pylint: disable=consider-using-from-import
 
     if cloud.async_active_subscription(hass):
         _LOGGER.debug("HYXI Push: Nabu Casa subscription detected, trying cloud URL")
         try:
-            resolved = cloud.async_get_external_url(hass, webhook_id)
-        except cloud.CloudNotConnected:
-            _LOGGER.debug(
-                "HYXI Push: Nabu Casa cloud not connected, falling back to network URL"
-            )
+            resolved = await cloud.async_get_or_create_cloudhook(hass, webhook_id)
+        except Exception as err:  # pylint: disable=broad-except
+            # Fall back to base Exception if CloudNotAvailable is not a valid exception class (e.g. in tests)
+            exc_cls = getattr(cloud, "CloudNotAvailable", Exception)
+            if not isinstance(exc_cls, type) or not issubclass(exc_cls, BaseException):
+                exc_cls = Exception
+            if isinstance(err, exc_cls):
+                _LOGGER.debug(
+                    "HYXI Push: Nabu Casa cloud hook not connected or available, falling back to network URL"
+                )
+            else:
+                raise err
 
     # Fall back to standard external network settings
     if not resolved:

--- a/tests/test_push_integration.py
+++ b/tests/test_push_integration.py
@@ -267,3 +267,45 @@ async def test_button_press_renew(mock_coordinator, mock_entry):
             mock_teardown.assert_called_once_with(hass, mock_coordinator, mock_entry)
             mock_setup.assert_called_once_with(hass, mock_entry, mock_coordinator)
             mock_coordinator.async_set_updated_data.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_push_subscription_via_nabu_casa(mock_coordinator, mock_entry):
+    """Test push subscription setup using Nabu Casa cloudhook URL resolution."""
+    hass = MagicMock()
+
+    import homeassistant.components.cloud as cloud_mock
+
+    old_active = cloud_mock.async_active_subscription
+    old_hook = getattr(cloud_mock, "async_get_or_create_cloudhook", None)
+
+    cloud_mock.async_active_subscription = MagicMock(return_value=True)
+    cloud_mock.async_get_or_create_cloudhook = AsyncMock(
+        return_value="https://hooks.nabucasa.com/12345"
+    )
+
+    try:
+        with patch("custom_components.hyxi_cloud.__init__.webhook") as mock_webhook:
+            mock_webhook.async_generate_path.return_value = (
+                "/api/webhook/hyxi_cloud_entry_123"
+            )
+
+            await _async_setup_push_subscription(hass, mock_entry, mock_coordinator)
+
+            assert mock_coordinator.push_enabled is True
+            assert mock_coordinator.webhook_id == "hyxi_cloud_entry_123"
+            assert mock_coordinator.push_status == "active"
+            assert mock_coordinator.push_url == "https://hooks.nabucasa.com/12345"
+
+            mock_webhook.async_register.assert_called_once()
+            mock_coordinator.client.subscribe_real_time_data.assert_called_once_with(
+                "https://hooks.nabucasa.com/12345",
+                ["INV123"],
+                10000,
+            )
+    finally:
+        cloud_mock.async_active_subscription = old_active
+        if old_hook is not None:
+            cloud_mock.async_get_or_create_cloudhook = old_hook
+        else:
+            delattr(cloud_mock, "async_get_or_create_cloudhook")


### PR DESCRIPTION
# Summary
This Pull Request fixes a startup crash during webhook resolution when an active Nabu Casa subscription is detected.

# Key Changes
- Replaced the incorrect call `cloud.async_get_external_url` with `await cloud.async_get_or_create_cloudhook`.
- Switched the import format to `import homeassistant.components.cloud as cloud` to play nicely with standard test mocking overlays.
- Added a defensive fallback for `CloudNotAvailable` inside the `except` block to prevent `TypeError` when the module is a mock in the test environment.
- Added `test_setup_push_subscription_via_nabu_casa` to assert correct cloudhook URL resolution and registration.

# Why this is needed
Ensures the real-time push subscriptions feature initializes without crashing for users utilizing Nabu Casa cloud access.