### PR TITLE
fix: resolve reload loop, telemetry sensor states, add telemetry logging, bump SDK to 1.3.1, and fix security alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,10 @@ The integration provides a **Subscription Status** sensor on your inverter's dev
 - **Attributes:** Displays URLs, subscriber codes, rates, errors, and the timestamp of the last received push frame.
 - **Renewal Button:** A stateless button entity **Renew Subscription** is provided to manually trigger unregistration and re-registration of the webhook if needed.
 
-##### Interaction with Polling (Fallback Loop)
+##### Interaction with Polling (Coexistence Loop)
 You do not need to disable or modify the standard polling interval when enabling push subscriptions:
-- **Automatic Back-Off:** When a real-time push update is successfully received, the integration immediately updates your entities and resets the polling timer. As long as push updates are actively arriving, regular API polling requests are skipped entirely, saving cloud API rate limits.
-- **Polling Fallback:** If push updates stop arriving (e.g., due to a network disruption, proxy failure, or cloud outage), the integration automatically falls back to standard REST API polling to ensure your sensors stay updated. Once push updates resume, polling backs off again.
+- **Coexistence and Syncing:** When a real-time push update is received, it immediately updates your sensors in Home Assistant. However, the standard background polling loop (default: 5 minutes) still runs periodically in the background to fetch and synchronize metrics that are only available via pull queries (such as grid power) and to act as a heartbeat fallback.
+- **Polling Fallback:** If push updates stop arriving (e.g., due to a network disruption, proxy failure, or cloud outage), standard REST API polling will continue as normal to keep your sensors updated.
 
 ### 🛡️ Reliability & Diagnostics
 

--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -35,6 +35,8 @@ from .const import (
     VERSION,
     detect_phase_type,
     get_raw_device_code,
+    mask_sensitive_key_value,
+    mask_sn,
     normalize_device_type,
 )
 from .coordinator import HyxiDataUpdateCoordinator
@@ -204,6 +206,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry when options change."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator is not None and coordinator.options == entry.options:
+        _LOGGER.debug(
+            "HYXI: Config entry data updated, skipping reload as options did not change"
+        )
+        return
     _LOGGER.debug("HYXI: Options updated, reloading integration to apply new settings")
     await hass.config_entries.async_reload(entry.entry_id)
 
@@ -529,9 +537,19 @@ async def _async_handle_webhook(
         _LOGGER.warning("Received invalid JSON payload on HYXI push webhook")
         return web.Response(status=400, text="Invalid JSON")
 
-    # 3. Process payload via SDK
+    # 3. Process payload via SDK merging with existing metrics
+    existing_metrics = {}
+    if coordinator.data:
+        existing_metrics = {
+            sn: dev_data.get("metrics", {})
+            for sn, dev_data in coordinator.data.items()
+            if dev_data
+        }
+
     try:
-        push_results = coordinator.client.process_push_data(payload)
+        push_results = coordinator.client.process_push_data(
+            payload, existing_metrics=existing_metrics
+        )
     except Exception as err:  # pylint: disable=broad-exception-caught
         _LOGGER.error("Error parsing push payload: %s", err)
         return web.Response(status=500, text="Internal Processing Error")
@@ -549,13 +567,23 @@ async def _async_handle_webhook(
             _LOGGER.warning("Received push data for untracked device SN: %s", sn)
             continue
 
-        coordinator.data[sn].setdefault("metrics", {}).update(device_update["metrics"])
+        coordinator.data[sn]["metrics"] = device_update["metrics"]
         any_updated = True
-        _LOGGER.debug("Updated device %s via push telemetry", sn)
+
+        # Log the push metrics with sensitive keys masked (using mask_sensitive_key_value)
+        logged_metrics = {
+            k: mask_sensitive_key_value(k, v)
+            for k, v in device_update["metrics"].items()
+        }
+        _LOGGER.debug(
+            "HYXI Push Telemetry Update for Device %s: %s",
+            mask_sn(sn),
+            logged_metrics,
+        )
 
     if any_updated:
         coordinator.last_push_received = dt_util.utcnow()
-        coordinator.async_set_updated_data(coordinator.data)
+        coordinator.async_update_listeners()
 
     return web.json_response({"code": "0", "msg": "Success", "success": True})
 
@@ -740,7 +768,8 @@ async def _async_handle_alarm_webhook(
     for sn, alarm_records in alarm_results.items():
         if sn not in coordinator.data:
             _LOGGER.warning(
-                "HYXI Alarm Push: received alarm for untracked device SN: %s", sn
+                "HYXI Alarm Push: received alarm for untracked device SN: %s",
+                mask_sn(sn),
             )
             continue
 
@@ -751,13 +780,20 @@ async def _async_handle_alarm_webhook(
             existing_by_code[rec["alarmCode"]] = rec
         coordinator.data[sn]["alarms"] = list(existing_by_code.values())
         any_updated = True
+
+        # Log the push alarms with sensitive keys masked (using mask_sensitive_key_value)
+        logged_alarms = []
+        for rec in alarm_records:
+            logged_rec = {k: mask_sensitive_key_value(k, v) for k, v in rec.items()}
+            logged_alarms.append(logged_rec)
+
         _LOGGER.debug(
-            "HYXI Alarm Push: updated %d alarm record(s) for device %s",
-            len(alarm_records),
-            sn,
+            "HYXI Alarm Push Telemetry Update for Device %s: %s",
+            mask_sn(sn),
+            logged_alarms,
         )
 
     if any_updated:
-        coordinator.async_set_updated_data(coordinator.data)
+        coordinator.async_update_listeners()
 
     return web.json_response({"code": "0", "msg": "Success", "success": True})

--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -28,9 +28,6 @@ from .const import (
 
 ACTIVE_ALARM_STATES = {"0", "1", "2", 0, 1, 2}
 
-# VPP-capable device types (must match HyxiApiClient._VPP_CAPABLE_TYPES)
-_VPP_CAPABLE_TYPES = {"INVERTER", "HYBRID_INVERTER", "ALL_IN_ONE", "ESS"}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -460,7 +460,7 @@ class HyxiRenewSubscriptionButton(ButtonEntity):
             )
 
             # Notify coordinator entities of change
-            self.coordinator.async_set_updated_data(self.coordinator.data)
+            self.coordinator.async_update_listeners()
         except Exception as err:
             _LOGGER.error("Failed to renew HYXI push subscription: %s", err)
             raise HomeAssistantError(f"Subscription renewal failed: {err}") from err

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -71,6 +71,38 @@ def mask_sn(sn: str) -> str:
     return hashlib.sha256(sn_str.encode("utf-8")).hexdigest()[:8]
 
 
+def mask_sensitive_key_value(key: str, value: Any) -> Any:
+    """Check if key contains sensitive info (SN, plant ID, IMEI, alias, address, etc.) and mask it."""
+    if value is None:
+        return None
+
+    sensitive_exact = {
+        "alias",
+        "plantaddress",
+        "plantname",
+        "devicename",
+        "alarmname",
+        "gprsimei",
+        "sn",
+        "plantid",
+        "parentsn",
+        "devicesn",
+        "batsn",
+        "emssn",
+    }
+
+    key_lower = str(key).lower()
+    if (
+        key_lower in sensitive_exact
+        or key_lower.endswith("sn")
+        or "plantid" in key_lower
+        or "imei" in key_lower
+    ):
+        return mask_sn(str(value))
+
+    return value
+
+
 def get_raw_device_code(dev_data: dict) -> str:
     """Extract the raw device type code from device data payload."""
     return (

--- a/custom_components/hyxi_cloud/coordinator.py
+++ b/custom_components/hyxi_cloud/coordinator.py
@@ -56,6 +56,7 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.client = client
         self.entry = entry
+        self.options = dict(entry.options)
         self.protection_controllers: dict[str, Any] = {}
         self.engine: Any = None
 
@@ -137,6 +138,41 @@ class HyxiDataUpdateCoordinator(DataUpdateCoordinator):
             self.hyxi_metadata["last_success"] = dt_util.utcnow()
             self.hyxi_metadata["api_status"] = "Online"
             self.hyxi_metadata["last_error"] = None
+
+            # Merge pulled metrics with existing cached metrics to preserve push-only keys
+            if self.data:
+                for sn, dev_data in devices.items():
+                    if sn in self.data:
+                        existing_metrics = dict(self.data[sn].get("metrics", {}))
+                        new_metrics = dev_data.get("metrics", {})
+
+                        # Update existing metrics with new values
+                        for k, v in new_metrics.items():
+                            if v is not None:
+                                existing_metrics[k] = v
+
+                        # Recalculate derived metrics on the merged dataset
+                        derived = self.client.compute_derived_metrics(
+                            existing_metrics, dev_data.get("device_type_code", "")
+                        )
+                        existing_metrics.update(derived)
+
+                        dev_data["metrics"] = existing_metrics
+
+            # Log the polled metrics for visibility
+            for sn, dev_data in devices.items():
+                if "metrics" in dev_data:
+                    from .const import mask_sensitive_key_value
+
+                    logged_metrics = {
+                        k: mask_sensitive_key_value(k, v)
+                        for k, v in dev_data["metrics"].items()
+                    }
+                    _LOGGER.debug(
+                        "HYXI Polled Telemetry for Device %s: %s",
+                        mask_sn(sn),
+                        logged_metrics,
+                    )
 
             # Return pure device dictionary
             await self._async_sync_device_metadata(devices)

--- a/custom_components/hyxi_cloud/engine.py
+++ b/custom_components/hyxi_cloud/engine.py
@@ -319,6 +319,7 @@ class EnergyManagerEngine:
             try:
                 return float(cap)
             except ValueError, TypeError:
+                # Ignore invalid battery capacity override value
                 pass
         api_cap = self._get_coordinator_metric("batCap", 0)
         if api_cap > 0:

--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -15,7 +15,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.3.0"
+    "hyxi-cloud-api>=1.3.1"
   ],
   "version": "1.6.0"
 }

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -381,6 +381,7 @@ class EMParameterNumber(NumberEntity, RestoreEntity):
             try:
                 self._attr_native_value = float(last_state.state)
             except ValueError, TypeError:
+                # Ignore invalid restored state on startup
                 pass
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -71,6 +71,7 @@ BATTERY_SENSORS = {
     "batVcl",
     "batTch",
     "batTcl",
+    "batTmp",
     "batIcm",
     "batIdm",
     "batCharge",
@@ -780,6 +781,14 @@ SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:thermometer-low",
+    ),
+    SensorEntityDescription(
+        key="batTmp",
+        native_unit_of_measurement="°C",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:thermometer",
     ),
     SensorEntityDescription(
         key="batIcm",

--- a/custom_components/hyxi_cloud/strings.json
+++ b/custom_components/hyxi_cloud/strings.json
@@ -433,6 +433,9 @@
       "battcl": {
         "name": "Min Cell Temperature"
       },
+      "battmp": {
+        "name": "Battery Temperature"
+      },
       "baticm": {
         "name": "Max Charging Current"
       },

--- a/custom_components/hyxi_cloud/translations/af.json
+++ b/custom_components/hyxi_cloud/translations/af.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batterytemperatuur"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/cs.json
+++ b/custom_components/hyxi_cloud/translations/cs.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Teplota baterie"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/da.json
+++ b/custom_components/hyxi_cloud/translations/da.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batteritemperatur"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/de.json
+++ b/custom_components/hyxi_cloud/translations/de.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batterietemperatur"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/en.json
+++ b/custom_components/hyxi_cloud/translations/en.json
@@ -432,6 +432,9 @@
       "battcl": {
         "name": "Min Cell Temperature"
       },
+      "battmp": {
+        "name": "Battery Temperature"
+      },
       "baticm": {
         "name": "Max Charging Current"
       },

--- a/custom_components/hyxi_cloud/translations/es.json
+++ b/custom_components/hyxi_cloud/translations/es.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Temperatura de la batería"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/fi.json
+++ b/custom_components/hyxi_cloud/translations/fi.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Akun lämpötila"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/fr.json
+++ b/custom_components/hyxi_cloud/translations/fr.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Température de la batterie"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/hu.json
+++ b/custom_components/hyxi_cloud/translations/hu.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Akkumulátor hőmérséklet"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/it.json
+++ b/custom_components/hyxi_cloud/translations/it.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Temperatura della batteria"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/ja.json
+++ b/custom_components/hyxi_cloud/translations/ja.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Battery Temperature"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/nb.json
+++ b/custom_components/hyxi_cloud/translations/nb.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batteritemperatur"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/nl.json
+++ b/custom_components/hyxi_cloud/translations/nl.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batterijtemperatuur"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/pl.json
+++ b/custom_components/hyxi_cloud/translations/pl.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Temperatura baterii"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/pt-BR.json
+++ b/custom_components/hyxi_cloud/translations/pt-BR.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Temperatura da bateria"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/pt.json
+++ b/custom_components/hyxi_cloud/translations/pt.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Temperatura da bateria"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/ru.json
+++ b/custom_components/hyxi_cloud/translations/ru.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Температура батареи"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/sv.json
+++ b/custom_components/hyxi_cloud/translations/sv.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batteritemperatur"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/tr.json
+++ b/custom_components/hyxi_cloud/translations/tr.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "Batarya Sıcaklığı"
       }
     },
     "number": {

--- a/custom_components/hyxi_cloud/translations/zh-Hans.json
+++ b/custom_components/hyxi_cloud/translations/zh-Hans.json
@@ -476,6 +476,9 @@
           "inactive": "Inactive",
           "error": "Error"
         }
+      },
+      "battmp": {
+        "name": "电池温度"
       }
     },
     "number": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.3.0"
+    "hyxi-cloud-api>=1.3.1"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.3.0
+hyxi-cloud-api>=1.3.1
 
 # Development/Linting tools
 ruff>=0.15.15

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.155.1
-hyxi-cloud-api>=1.3.0
+hyxi-cloud-api>=1.3.1
 pytest-homeassistant-custom-component>=0.13.334

--- a/tests/test_alarm_push.py
+++ b/tests/test_alarm_push.py
@@ -64,7 +64,7 @@ def mock_coordinator():
     coord.client.subscribe_alarm = AsyncMock(
         return_value={"success": True, "data": {"subscribeCode": "alarm_code_abc"}}
     )
-    coord.async_set_updated_data = MagicMock()
+    coord.async_update_listeners = MagicMock()
     return coord
 
 
@@ -211,7 +211,7 @@ async def test_handle_alarm_webhook_merges_records(mock_hass, mock_coordinator):
     # Verify 768 was updated from state "0" → "1"
     code_768 = next(a for a in alarms if a["alarmCode"] == "768")
     assert code_768["alarmState"] == "1"
-    mock_coordinator.async_set_updated_data.assert_called_once()
+    mock_coordinator.async_update_listeners.assert_called_once()
     # Timestamp must be set on any valid delivery, including ones with alarm data
     assert mock_coordinator.alarm_last_push_received is not None
 
@@ -272,6 +272,7 @@ async def test_handle_alarm_webhook_untracked_device(mock_hass, mock_coordinator
     assert response.status == 200
     # coordinator data for SN001 should be untouched
     assert mock_coordinator.data["SN001"]["alarms"] == []
-    mock_coordinator.async_set_updated_data.assert_not_called()
+    mock_coordinator.async_update_listeners.assert_not_called()
+
     # Timestamp IS set — the push was valid and parseable even though SN was unknown
     assert mock_coordinator.alarm_last_push_received is not None

--- a/tests/test_push_integration.py
+++ b/tests/test_push_integration.py
@@ -194,13 +194,14 @@ async def test_webhook_handler_success(mock_coordinator):
 
         # Verify SDK process method was called
         mock_coordinator.client.process_push_data.assert_called_once_with(
-            {"dataList": [{"deviceSn": "INV123", "batSoc": 85}]}
+            {"dataList": [{"deviceSn": "INV123", "batSoc": 85}]},
+            existing_metrics={"INV123": {}},
         )
 
-        # Verify coordinator data updated and set_updated_data called
+        # Verify coordinator data updated and update_listeners called
         assert mock_coordinator.data["INV123"]["metrics"]["batSoc"] == 85
         assert mock_coordinator.last_push_received is not None
-        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_coordinator.async_update_listeners.assert_called_once()
         mock_json_res.assert_called_once_with(
             {"code": "0", "msg": "Success", "success": True}
         )
@@ -266,7 +267,7 @@ async def test_button_press_renew(mock_coordinator, mock_entry):
 
             mock_teardown.assert_called_once_with(hass, mock_coordinator, mock_entry)
             mock_setup.assert_called_once_with(hass, mock_entry, mock_coordinator)
-            mock_coordinator.async_set_updated_data.assert_called_once()
+            mock_coordinator.async_update_listeners.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request - Resolve Reload Loop, Telemetry Sensor States, Add Telemetry Logging, and Fix Code Scanning Alerts

## Summary
Resolves the configuration reload loop caused by programmatic updates, fixes stale sensor states by merging webhook push and REST polling data streams (utilizing SDK `1.3.1`), adds comprehensive log sanitization and telemetry debug logging, adds the new `batTmp` diagnostic sensor, and resolves CodeQL Alert #91 and Alert #76 (plus proactive cleanups for the same pattern).

## Key Changes
* **Reload Loop Protection:** Added guard in `async_reload_entry` to verify that `entry.options` have changed compared to cached update coordinator options before reloading the integration.
* **Telemetry Data Merging:**
  * Switched push/alarm webhooks from `async_set_updated_data()` to `async_update_listeners()`, bypassing poll timer resets and preserving the 5-minute background sync.
  * Merged incoming REST API poll data into coordinator memory instead of overwriting, preserving push-only metrics (like phase load powers).
  * Passed coordinator cache to the SDK webhook process (`process_push_data`) to prevent overwriting pull-only metrics (like `gridP`) with `None`.
* **Telemetry Logging & Sanitization:**
  * Created standard `mask_sensitive_key_value` key/value masker helper in `const.py` to securely mask serial numbers, plant IDs, and IMEIs case-insensitively using SHA-256 (first 8 hex characters).
  * Added detailed masked logs for `HYXI Polled Telemetry`, `HYXI Push Telemetry Update`, and `HYXI Alarm Push Telemetry Update`.
* **Sensor Addition:** Added `"batTmp"` (Battery Temperature) to the battery sensors list and translations, synchronized across all 20 supported languages.
* **Security & Code Scanning Fixes:**
  * **Alert #91 Resolution:** Removed the unused global variable `_VPP_CAPABLE_TYPES` from `binary_sensor.py` (rendered obsolete after VPP check was refactored to HA-style normalization).
  * **Alert #76 Resolution:** Added explanation comments to empty exception handling (`except ...: pass`) blocks in `number.py` and `engine.py` to prevent silent suppression warnings and maintain a clean audit trail.
* **Dependency Bump:** Updated requirements files, `pyproject.toml`, and `manifest.json` to require `hyxi-cloud-api>=1.3.1`.

## Why this is needed
1. **Reload Loop:** Updating data in config entries was triggering options flow updates, causing Home Assistant to continually reload the integration.
2. **Stale Data:** Webhook push payloads are partial (contain phase loads but omit grid power). Background polls contain grid power but lack phase loads. Overwriting coordinator memory on either path caused sensors to become stale or bounce to `None`.
3. **Security Audit Trail:** Device serial numbers and plant IDs were being logged in raw form in webhook diagnostics; they are now fully masked deterministically. Unused code is pruned and silent exception handling blocks are commented to ensure audit-readiness.