### PR TITLE
🧪 test: Add test coverage for `_note_manual_mode` in button platform

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -496,3 +496,23 @@ async def test_clear_alarms_button_error(mock_coordinator_fixture):
 
     with pytest.raises(button_mod.HyxiApiClient.ControlError):
         await btn.async_press()
+
+
+def test_note_manual_mode():
+    """Test tracking the last user-sent inverter mode."""
+    coordinator = MagicMock()
+    controller = MagicMock()
+    coordinator.protection_controllers = {"SN123": controller}
+
+    button_mod._note_manual_mode(coordinator, "SN123", "test_mode")
+
+    controller.note_manual_mode.assert_called_once_with("test_mode")
+
+
+def test_note_manual_mode_no_controller():
+    """Test tracking mode does not fail when no controller is available."""
+    coordinator = MagicMock()
+    coordinator.protection_controllers = {}
+
+    # Should not raise an exception
+    button_mod._note_manual_mode(coordinator, "SN123", "test_mode")


### PR DESCRIPTION
🎯 **What:** Adds unit tests to cover the `_note_manual_mode` battery protection telemetry function in the `button` platform.
📊 **Coverage:** The tests cover the happy path where a protection controller is found on the coordinator and asserts that `note_manual_mode` was successfully called. It also covers the edge case where no controller is present, ensuring that the function executes safely without throwing exceptions.
✨ **Result:** Improved test coverage and reliability for battery telemetry tracking.

---
*PR created automatically by Jules for task [8896153549315304784](https://jules.google.com/task/8896153549315304784) started by @Veldkornet*