### PR TITLE
fix: mask untracked device serial number in push warning log

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -564,7 +564,9 @@ async def _async_handle_webhook(
 
     for sn, device_update in push_results.items():
         if sn not in coordinator.data:
-            _LOGGER.warning("Received push data for untracked device SN: %s", sn)
+            _LOGGER.warning(
+                "Received push data for untracked device SN: %s", mask_sn(sn)
+            )
             continue
 
         coordinator.data[sn]["metrics"] = device_update["metrics"]


### PR DESCRIPTION
# Summary
This PR fixes a security/privacy exposure where an untracked device's serial number was logged in plain text when receiving push telemetry.

# Key Changes
- Masked the serial number utilizing  in the warning log block in .

# Why this is needed
To prevent logging sensitive device serial numbers in plain text, maintaining compliance with our security best practices.