### PR TITLE
🧪 test: add unit test for note_manual_mode

### DIFF
--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -299,6 +299,18 @@ async def test_async_stop_cancels_evaluation_task():
     assert controller._eval_task is None
 
 
+def test_note_manual_mode():
+    """Verify note_manual_mode correctly updates the last sent mode attribute."""
+    controller = _build_controller(50)
+    assert controller.last_sent_mode is None
+
+    controller.note_manual_mode("charge")
+    assert controller.last_sent_mode == "charge"
+
+    controller.note_manual_mode("idle")
+    assert controller.last_sent_mode == "idle"
+
+
 def test_restore_last_sent_mode_invalid():
     """Verify restore_last_sent_mode ignores invalid/unsupported modes."""
     controller = _build_controller(50)


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `note_manual_mode` method in `HyxiBatteryProtectionController`.
📊 **Coverage:** The test explicitly verifies that the `note_manual_mode` correctly updates the internal attribute state (`_last_sent_mode` / `last_sent_mode`), covering the basic intended behavior of the function.
✨ **Result:** Improved test coverage and reliability by explicitly testing the public track method independently.

---
*PR created automatically by Jules for task [11088178246802988425](https://jules.google.com/task/11088178246802988425) started by @Veldkornet*