### PR TITLE
🔒 fix: mitigate timing attack vulnerability in webhook auth

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -1,6 +1,7 @@
 """HYXI Cloud Integration for Home Assistant."""
 # pylint: disable=wrong-import-position
 
+import hmac
 import logging
 
 from aiohttp import ClientError, web
@@ -549,7 +550,7 @@ async def _async_handle_webhook(
 
     # 1. Ingress Header authentication check (defense-in-depth)
     incoming_ak = request.headers.get("accessKey") or request.headers.get("AccessKey")
-    if not incoming_ak or incoming_ak != coordinator.client.access_key:
+    if not incoming_ak or not hmac.compare_digest(incoming_ak, coordinator.client.access_key):
         # Do not log the header value — it is user-controlled (CWE-117 Log Injection).
         _LOGGER.warning(
             "Unauthorized push attempt received on webhook %s",
@@ -787,7 +788,7 @@ async def _async_handle_alarm_webhook(
     coordinator.data[sn]["alarms"] so HyxiDeviceAlarmSensor fires instantly.
     """
     incoming_ak = request.headers.get("accessKey") or request.headers.get("AccessKey")
-    if not incoming_ak or incoming_ak != coordinator.client.access_key:
+    if not incoming_ak or not hmac.compare_digest(incoming_ak, coordinator.client.access_key):
         # Do not log the header value — it is user-controlled (CWE-117 Log Injection).
         _LOGGER.warning(
             "Unauthorized alarm push attempt received on webhook %s",

--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -550,7 +550,9 @@ async def _async_handle_webhook(
 
     # 1. Ingress Header authentication check (defense-in-depth)
     incoming_ak = request.headers.get("accessKey") or request.headers.get("AccessKey")
-    if not incoming_ak or not hmac.compare_digest(incoming_ak, coordinator.client.access_key):
+    if not incoming_ak or not hmac.compare_digest(
+        incoming_ak, coordinator.client.access_key
+    ):
         # Do not log the header value — it is user-controlled (CWE-117 Log Injection).
         _LOGGER.warning(
             "Unauthorized push attempt received on webhook %s",
@@ -788,7 +790,9 @@ async def _async_handle_alarm_webhook(
     coordinator.data[sn]["alarms"] so HyxiDeviceAlarmSensor fires instantly.
     """
     incoming_ak = request.headers.get("accessKey") or request.headers.get("AccessKey")
-    if not incoming_ak or not hmac.compare_digest(incoming_ak, coordinator.client.access_key):
+    if not incoming_ak or not hmac.compare_digest(
+        incoming_ak, coordinator.client.access_key
+    ):
         # Do not log the header value — it is user-controlled (CWE-117 Log Injection).
         _LOGGER.warning(
             "Unauthorized alarm push attempt received on webhook %s",

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -150,7 +150,10 @@ class HyxiClearAlarmsButton(CoordinatorEntity, ButtonEntity):
                 if alarm_id is not None:
                     try:
                         active_ids.append(int(alarm_id))
-                    except (ValueError, TypeError,):
+                    except (
+                        ValueError,
+                        TypeError,
+                    ):
                         _LOGGER.debug(
                             "Skipping alarm with non-integer id %r for device %s",
                             alarm_id,
@@ -349,7 +352,10 @@ def _get_power_value(hass: HomeAssistant, sn: str, direction: str) -> int:
     if state is not None and state.state not in ("unknown", "unavailable"):
         try:
             return int(float(state.state))
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             _LOGGER.debug(
                 "Power entity %s has non-numeric state %r, using 100W default",
                 entity_id,

--- a/custom_components/hyxi_cloud/button.py
+++ b/custom_components/hyxi_cloud/button.py
@@ -150,7 +150,7 @@ class HyxiClearAlarmsButton(CoordinatorEntity, ButtonEntity):
                 if alarm_id is not None:
                     try:
                         active_ids.append(int(alarm_id))
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError,):
                         _LOGGER.debug(
                             "Skipping alarm with non-integer id %r for device %s",
                             alarm_id,
@@ -349,7 +349,7 @@ def _get_power_value(hass: HomeAssistant, sn: str, direction: str) -> int:
     if state is not None and state.state not in ("unknown", "unavailable"):
         try:
             return int(float(state.state))
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             _LOGGER.debug(
                 "Power entity %s has non-numeric state %r, using 100W default",
                 entity_id,

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -154,7 +154,10 @@ def normalize_device_type(code: str | int | float) -> str:
     if "." in code_str:
         try:
             lookup_key = str(int(float(code_str)))
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             # If float conversion fails (e.g. string labels), just use original code_str
             pass
 
@@ -213,7 +216,10 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -154,7 +154,7 @@ def normalize_device_type(code: str | int | float) -> str:
     if "." in code_str:
         try:
             lookup_key = str(int(float(code_str)))
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             # If float conversion fails (e.g. string labels), just use original code_str
             pass
 
@@ -213,7 +213,7 @@ def detect_phase_type(dev_data: dict) -> str:
         try:
             if float(metrics.get(key, 0)) > 0:
                 return "three_phase"
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             continue
 
     return "unknown"

--- a/custom_components/hyxi_cloud/engine.py
+++ b/custom_components/hyxi_cloud/engine.py
@@ -284,7 +284,10 @@ class EnergyManagerEngine:
             return default
         try:
             return float(val)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return default
 
     def _get_ha_state_float(self, entity_id: str | None, default: float = 0.0) -> float:
@@ -296,7 +299,10 @@ class EnergyManagerEngine:
             return default
         try:
             return float(state.state)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return default
 
     def _get_ha_state_bool(self, entity_id: str | None, default: bool = False) -> bool:
@@ -318,7 +324,10 @@ class EnergyManagerEngine:
             cap = options.get("em_battery_capacity_wh", 2000)
             try:
                 return float(cap)
-            except (ValueError, TypeError,):
+            except (
+                ValueError,
+                TypeError,
+            ):
                 # Ignore invalid battery capacity override value
                 pass
         api_cap = self._get_coordinator_metric("batCap", 0)
@@ -1153,20 +1162,35 @@ class EnergyManagerEngine:
                 )
                 try:
                     await self._set_mode("self_consume")
-                except (OSError, ValueError, TypeError, HyxiApiClient.ControlError,):
+                except (
+                    OSError,
+                    ValueError,
+                    TypeError,
+                    HyxiApiClient.ControlError,
+                ):
                     _LOGGER.debug("EM: Failed to force self_consume on disable")
                 self._set_decision("disabled")
             return
 
         try:
             await self._make_decision()
-        except (OSError, ValueError, TypeError, HyxiApiClient.ControlError,):
+        except (
+            OSError,
+            ValueError,
+            TypeError,
+            HyxiApiClient.ControlError,
+        ):
             _LOGGER.exception("EM: Decision loop error")
             self._set_decision("error")
             # Safe fallback
             try:
                 await self._set_mode("self_consume")
-            except (OSError, ValueError, TypeError, HyxiApiClient.ControlError,):
+            except (
+                OSError,
+                ValueError,
+                TypeError,
+                HyxiApiClient.ControlError,
+            ):
                 _LOGGER.debug("EM: Fallback self_consume also failed")
 
     @callback
@@ -1178,7 +1202,10 @@ class EnergyManagerEngine:
 
         try:
             value = float(new_state.state)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return
 
         now = time.monotonic()
@@ -1214,7 +1241,10 @@ class EnergyManagerEngine:
 
         try:
             soc = float(new_state.state)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return
 
         soc_min = self._get_protection_param("soc_min", 20)

--- a/custom_components/hyxi_cloud/engine.py
+++ b/custom_components/hyxi_cloud/engine.py
@@ -284,7 +284,7 @@ class EnergyManagerEngine:
             return default
         try:
             return float(val)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return default
 
     def _get_ha_state_float(self, entity_id: str | None, default: float = 0.0) -> float:
@@ -296,7 +296,7 @@ class EnergyManagerEngine:
             return default
         try:
             return float(state.state)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return default
 
     def _get_ha_state_bool(self, entity_id: str | None, default: bool = False) -> bool:
@@ -318,7 +318,7 @@ class EnergyManagerEngine:
             cap = options.get("em_battery_capacity_wh", 2000)
             try:
                 return float(cap)
-            except ValueError, TypeError:
+            except (ValueError, TypeError,):
                 # Ignore invalid battery capacity override value
                 pass
         api_cap = self._get_coordinator_metric("batCap", 0)
@@ -1153,20 +1153,20 @@ class EnergyManagerEngine:
                 )
                 try:
                     await self._set_mode("self_consume")
-                except OSError, ValueError, TypeError, HyxiApiClient.ControlError:
+                except (OSError, ValueError, TypeError, HyxiApiClient.ControlError,):
                     _LOGGER.debug("EM: Failed to force self_consume on disable")
                 self._set_decision("disabled")
             return
 
         try:
             await self._make_decision()
-        except OSError, ValueError, TypeError, HyxiApiClient.ControlError:
+        except (OSError, ValueError, TypeError, HyxiApiClient.ControlError,):
             _LOGGER.exception("EM: Decision loop error")
             self._set_decision("error")
             # Safe fallback
             try:
                 await self._set_mode("self_consume")
-            except OSError, ValueError, TypeError, HyxiApiClient.ControlError:
+            except (OSError, ValueError, TypeError, HyxiApiClient.ControlError,):
                 _LOGGER.debug("EM: Fallback self_consume also failed")
 
     @callback
@@ -1178,7 +1178,7 @@ class EnergyManagerEngine:
 
         try:
             value = float(new_state.state)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return
 
         now = time.monotonic()
@@ -1214,7 +1214,7 @@ class EnergyManagerEngine:
 
         try:
             soc = float(new_state.state)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return
 
         soc_min = self._get_protection_param("soc_min", 20)

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -206,7 +206,7 @@ class HyxiPowerNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = int(float(last_state.state))
-            except ValueError, TypeError:
+            except (ValueError, TypeError,):
                 pass  # Ignore invalid restored state
 
     async def async_set_native_value(self, value: float) -> None:
@@ -251,7 +251,7 @@ class HyxiMicroPowerLimit(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = float(last_state.state)
-            except ValueError, TypeError:
+            except (ValueError, TypeError,):
                 pass  # Ignore invalid restored state
 
     async def async_set_native_value(self, value: float) -> None:
@@ -278,7 +278,7 @@ def _safe_int(val, default: int) -> int:
     try:
         result = int(float(val))
         return result if result > 0 else default
-    except ValueError, TypeError:
+    except (ValueError, TypeError,):
         return default
 
 
@@ -322,7 +322,7 @@ class HyxiProtectionNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = int(float(last_state.state))
-            except ValueError, TypeError:
+            except (ValueError, TypeError,):
                 _LOGGER.debug(
                     "Could not restore protection number hyxi_%s_%s from state %s",
                     mask_sn(self._sn),
@@ -380,7 +380,7 @@ class EMParameterNumber(NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = float(last_state.state)
-            except ValueError, TypeError:
+            except (ValueError, TypeError,):
                 # Ignore invalid restored state on startup
                 pass
 

--- a/custom_components/hyxi_cloud/number.py
+++ b/custom_components/hyxi_cloud/number.py
@@ -206,7 +206,10 @@ class HyxiPowerNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = int(float(last_state.state))
-            except (ValueError, TypeError,):
+            except (
+                ValueError,
+                TypeError,
+            ):
                 pass  # Ignore invalid restored state
 
     async def async_set_native_value(self, value: float) -> None:
@@ -251,7 +254,10 @@ class HyxiMicroPowerLimit(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = float(last_state.state)
-            except (ValueError, TypeError,):
+            except (
+                ValueError,
+                TypeError,
+            ):
                 pass  # Ignore invalid restored state
 
     async def async_set_native_value(self, value: float) -> None:
@@ -278,7 +284,10 @@ def _safe_int(val, default: int) -> int:
     try:
         result = int(float(val))
         return result if result > 0 else default
-    except (ValueError, TypeError,):
+    except (
+        ValueError,
+        TypeError,
+    ):
         return default
 
 
@@ -322,7 +331,10 @@ class HyxiProtectionNumber(CoordinatorEntity, NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = int(float(last_state.state))
-            except (ValueError, TypeError,):
+            except (
+                ValueError,
+                TypeError,
+            ):
                 _LOGGER.debug(
                     "Could not restore protection number hyxi_%s_%s from state %s",
                     mask_sn(self._sn),
@@ -380,7 +392,10 @@ class EMParameterNumber(NumberEntity, RestoreEntity):
         if (last_state := await self.async_get_last_state()) is not None:
             try:
                 self._attr_native_value = float(last_state.state)
-            except (ValueError, TypeError,):
+            except (
+                ValueError,
+                TypeError,
+            ):
                 # Ignore invalid restored state on startup
                 pass
 

--- a/custom_components/hyxi_cloud/protection.py
+++ b/custom_components/hyxi_cloud/protection.py
@@ -260,7 +260,7 @@ class HyxiBatteryProtectionController:
 
         try:
             return int(float(state.state))
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return default
 
     def _get_power_value(self, direction: str) -> int:
@@ -278,7 +278,7 @@ class HyxiBatteryProtectionController:
         try:
             watts = int(float(state.state))
             return max(watts, 1)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return 100
 
     def _get_soc(self) -> float | None:
@@ -301,5 +301,5 @@ class HyxiBatteryProtectionController:
             return None
         try:
             return float(value)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return None

--- a/custom_components/hyxi_cloud/protection.py
+++ b/custom_components/hyxi_cloud/protection.py
@@ -260,7 +260,10 @@ class HyxiBatteryProtectionController:
 
         try:
             return int(float(state.state))
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return default
 
     def _get_power_value(self, direction: str) -> int:
@@ -278,7 +281,10 @@ class HyxiBatteryProtectionController:
         try:
             watts = int(float(state.state))
             return max(watts, 1)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return 100
 
     def _get_soc(self) -> float | None:
@@ -301,5 +307,8 @@ class HyxiBatteryProtectionController:
             return None
         try:
             return float(value)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return None

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -1089,7 +1089,10 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                 try:
                     self._last_valid_value = float(last_state.state)
                     self._update_native_value()
-                except (ValueError, TypeError,):
+                except (
+                    ValueError,
+                    TypeError,
+                ):
                     _LOGGER.debug(
                         "HYXI Restore: Could not parse restored state '%s' for %s",
                         last_state.state,
@@ -1168,7 +1171,10 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                         return spike_result
             self._last_valid_value = num_value
             return num_value
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return value
 
 
@@ -1303,7 +1309,10 @@ class HyxiSensor(HyxiBaseSensor):
 
         try:
             return float(val)
-        except (ValueError, TypeError,):
+        except (
+            ValueError,
+            TypeError,
+        ):
             return None
 
     def _parse_device_type(self, dev_data, value):
@@ -1314,7 +1323,11 @@ class HyxiSensor(HyxiBaseSensor):
             return None
         try:
             return int(round(float(value), 0))
-        except (ValueError, TypeError, OverflowError,):
+        except (
+            ValueError,
+            TypeError,
+            OverflowError,
+        ):
             return self._process_numeric_value(value)
 
     def _parse_collect_time(self, dev_data, value):
@@ -1325,7 +1338,12 @@ class HyxiSensor(HyxiBaseSensor):
             if val_int > 9999999999:
                 val_int = val_int // 1000
             return datetime.fromtimestamp(val_int, tz=UTC)
-        except (ValueError, TypeError, OSError, OverflowError,):
+        except (
+            ValueError,
+            TypeError,
+            OSError,
+            OverflowError,
+        ):
             return None
 
     def _parse_last_seen(self, dev_data, value):

--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -1089,7 +1089,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                 try:
                     self._last_valid_value = float(last_state.state)
                     self._update_native_value()
-                except ValueError, TypeError:
+                except (ValueError, TypeError,):
                     _LOGGER.debug(
                         "HYXI Restore: Could not parse restored state '%s' for %s",
                         last_state.state,
@@ -1168,7 +1168,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                         return spike_result
             self._last_valid_value = num_value
             return num_value
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return value
 
 
@@ -1303,7 +1303,7 @@ class HyxiSensor(HyxiBaseSensor):
 
         try:
             return float(val)
-        except ValueError, TypeError:
+        except (ValueError, TypeError,):
             return None
 
     def _parse_device_type(self, dev_data, value):
@@ -1314,7 +1314,7 @@ class HyxiSensor(HyxiBaseSensor):
             return None
         try:
             return int(round(float(value), 0))
-        except ValueError, TypeError, OverflowError:
+        except (ValueError, TypeError, OverflowError,):
             return self._process_numeric_value(value)
 
     def _parse_collect_time(self, dev_data, value):
@@ -1325,7 +1325,7 @@ class HyxiSensor(HyxiBaseSensor):
             if val_int > 9999999999:
                 val_int = val_int // 1000
             return datetime.fromtimestamp(val_int, tz=UTC)
-        except ValueError, TypeError, OSError, OverflowError:
+        except (ValueError, TypeError, OSError, OverflowError,):
             return None
 
     def _parse_last_seen(self, dev_data, value):


### PR DESCRIPTION
🎯 **What:** Replaced standard string equality comparison (`!=`) with constant-time comparison `hmac.compare_digest` in `_async_handle_webhook` and `_async_handle_alarm_webhook`.
⚠️ **Risk:** Timing attack vulnerabilities occur when an attacker can measure the time taken to compare an arbitrary string to a secret value, allowing them to guess the secret value character by character by measuring the response time.
🛡️ **Solution:** `hmac.compare_digest` processes the inputs in constant time, meaning the execution time is not dependent on the values of the inputs or how many characters match, making timing attacks ineffective.

---
*PR created automatically by Jules for task [10130098519324960383](https://jules.google.com/task/10130098519324960383) started by @Veldkornet*