### PR TITLE
🧪 Add missing unit test for EnergyManagerEngine.p1_avg

### DIFF
--- a/tests/integration/test_real_engine.py
+++ b/tests/integration/test_real_engine.py
@@ -552,3 +552,24 @@ async def test_engine_callbacks_and_staleness(hass: HomeAssistant):
 
     await engine.async_stop()
     await hass.async_block_till_done()
+
+
+def test_engine_p1_avg():
+    """Test the p1_avg property of EnergyManagerEngine."""
+    coordinator = MagicMock()
+    config = EMEntityConfig(sn="SN123", p1_entity="sensor.p1_meter")
+    engine = EnergyManagerEngine(MagicMock(), coordinator, config)
+
+    assert engine.p1_avg == 0.0
+
+    # Add one value
+    engine._p1_buffer.append((1.0, 100.0))
+    assert engine.p1_avg == 100.0
+
+    # Add second value
+    engine._p1_buffer.append((2.0, 300.0))
+    assert engine.p1_avg == 200.0
+
+    # Add third value
+    engine._p1_buffer.append((3.0, -100.0))
+    assert engine.p1_avg == 100.0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `p1_avg` property on `EnergyManagerEngine` was entirely untested.
📊 **Coverage:** Added an integration test `test_engine_p1_avg` to verify `p1_avg` correctly returns `0.0` when the buffer is empty, and accurately calculates the rolling average for single and multiple entries.
✨ **Result:** Improved test coverage for `EnergyManagerEngine` property getters.

---
*PR created automatically by Jules for task [15976703588540126943](https://jules.google.com/task/15976703588540126943) started by @Veldkornet*