### PR TITLE
🧪 Add unit test for current_mode property in EnergyManagerEngine

### DIFF
--- a/tests/integration/test_real_engine.py
+++ b/tests/integration/test_real_engine.py
@@ -555,6 +555,21 @@ async def test_engine_callbacks_and_staleness(hass: HomeAssistant):
     await hass.async_block_till_done()
 
 
+def test_engine_current_mode():
+    """Test the current_mode property of EnergyManagerEngine."""
+    coordinator = MagicMock()
+    config = EMEntityConfig(sn="SN123", p1_entity="sensor.p1_meter")
+    engine = EnergyManagerEngine(MagicMock(), coordinator, config)
+
+    assert engine.current_mode is None
+
+    engine._current_mode = "charge"
+    assert engine.current_mode == "charge"
+
+    engine._current_mode = "discharge"
+    assert engine.current_mode == "discharge"
+
+
 def test_engine_p1_avg():
     """Test the p1_avg property of EnergyManagerEngine."""
     coordinator = MagicMock()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `current_mode` public property of the `EnergyManagerEngine` class was completely untested.

📊 **Coverage:** What scenarios are now tested
Added `test_engine_current_mode` in `tests/integration/test_real_engine.py` which covers:
- Initial state where `current_mode` is `None`
- Setting the internal `_current_mode` property to 'charge' and retrieving it via the public property.
- Setting the internal `_current_mode` property to 'discharge' and retrieving it.

✨ **Result:** The improvement in test coverage
Increased test coverage for `EnergyManagerEngine` properties ensuring the getter returns the correct internal state reliably.

---
*PR created automatically by Jules for task [12691209354355795033](https://jules.google.com/task/12691209354355795033) started by @Veldkornet*