### PR TITLE
Refactor EMBinarySensor is_on function for code health

### DIFF
--- a/custom_components/hyxi_cloud/binary_sensor.py
+++ b/custom_components/hyxi_cloud/binary_sensor.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from collections.abc import Callable
+from typing import Any, ClassVar
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -294,6 +295,13 @@ class EMBinarySensor(BinarySensorEntity):
         "high_load_detected": "mdi:flash-alert",
     }
 
+    _STATE_FUNCS: ClassVar[dict[str, Callable[[Any], bool]]] = {
+        "night_mode_active": lambda engine: engine._is_night(),
+        "high_load_detected": lambda engine: (
+            engine._get_home_load() > engine._get_param("high_load_threshold")
+        ),
+    }
+
     def __init__(
         self,
         coordinator,
@@ -309,6 +317,7 @@ class EMBinarySensor(BinarySensorEntity):
         self._attr_translation_key = f"em_{key}"
         self._attr_device_info = device_info
         self._attr_icon = self._ICONS.get(key)
+        self._state_func = self._STATE_FUNCS.get(key)
 
     async def async_added_to_hass(self) -> None:
         """Register for engine updates."""
@@ -331,12 +340,6 @@ class EMBinarySensor(BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return the current value from the engine."""
         engine = self._coordinator.engine
-        if not engine:
+        if not engine or not self._state_func:
             return None
-        if self._key == "night_mode_active":
-            return engine._is_night()
-        if self._key == "high_load_detected":
-            home_load = engine._get_home_load()
-            threshold = engine._get_param("high_load_threshold")
-            return home_load > threshold
-        return None
+        return self._state_func(engine)


### PR DESCRIPTION
## Summary
This PR refactors the state evaluation logic for the Energy Manager binary sensors (`EMBinarySensor`) in the `ha-hyxi-cloud` Home Assistant integration. It replaces conditional statement branches in `is_on()` with a class-level dictionary lookup resolved during object initialization.

## Key Changes
* Created a class-level `_STATE_FUNCS` mapping keys (`night_mode_active`, `high_load_detected`) to their respective lambda evaluations.
* Caches the resolved state function as `self._state_func` in `__init__`.
* Simplifies the `is_on` property logic to a clean, fast function call: `self._state_func(engine)`.
* Kept `.python-version` and `requirements.txt` intact, avoiding the regression issues present in the previous PR.

## Why this is needed
This refactor reduces cyclomatic complexity and improves maintainability of the `EMBinarySensor` codebase. By avoiding the dependency downgrade (`hyxi-cloud-api>=1.1.3`), we maintain version consistency with `manifest.json` (which requires `>=1.3.6`) and pass Home Assistant `hassfest` checks.
