### PR TITLE
Fix webhook logging and SN masking data leak

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -42,6 +42,7 @@ from .const import (
     get_raw_device_code,
     mask_sensitive_key_value,
     mask_sn,
+    mask_url,
     normalize_device_type,
 )
 from .coordinator import HyxiDataUpdateCoordinator
@@ -329,7 +330,8 @@ async def _async_resolve_webhook_url(
         base = custom_url.strip().rstrip("/")
         resolved = base + webhook.async_generate_path(webhook_id)
         _LOGGER.info(
-            "HYXI Push: Using custom base URL, callback endpoint: %s", resolved
+            "HYXI Push: Using custom base URL, callback endpoint: %s",
+            mask_url(resolved),
         )
         return resolved
 
@@ -362,7 +364,8 @@ async def _async_resolve_webhook_url(
                 hass, allow_external=True
             ) + webhook.async_generate_path(webhook_id)
             _LOGGER.debug(
-                "HYXI Push: Resolved callback URL via network helper: %s", resolved
+                "HYXI Push: Resolved callback URL via network helper: %s",
+                mask_url(resolved),
             )
         except network.NoURLAvailableError:
             _LOGGER.debug(
@@ -446,8 +449,8 @@ async def _async_setup_push_subscription(  # pylint: disable=too-many-statements
 
     _LOGGER.debug(
         "Subscribing callback URL %s for devices: %s",
-        webhook_url,
-        device_sns,
+        mask_url(webhook_url),
+        [mask_sn(sn) for sn in device_sns],
     )
 
     try:
@@ -569,7 +572,7 @@ async def _async_handle_webhook(
 
     _LOGGER.debug(
         "HYXI Cloud Data Push webhook callback received. Webhook ID: %s, Active Subscribe Code: %s",
-        webhook_id,
+        "hyxi_cloud_***" if webhook_id.startswith("hyxi_cloud_") else "***",
         coordinator.subscribe_code,
     )
 
@@ -691,7 +694,7 @@ async def _async_setup_alarm_subscription(
     _LOGGER.debug(
         "HYXI Alarm Push: Subscribing %s devices at %s",
         len(device_sns),
-        webhook_url,
+        mask_url(webhook_url),
     )
 
     try:
@@ -811,7 +814,7 @@ async def _async_handle_alarm_webhook(
 
     _LOGGER.debug(
         "HYXI Cloud Alarm Push webhook callback received. Webhook ID: %s, Active Subscribe Code: %s",
-        webhook_id,
+        "hyxi_cloud_***" if webhook_id.startswith("hyxi_cloud_") else "***",
         coordinator.alarm_subscribe_code,
     )
 

--- a/custom_components/hyxi_cloud/const.py
+++ b/custom_components/hyxi_cloud/const.py
@@ -70,6 +70,29 @@ def mask_sn(sn: str) -> str:
     return hashlib.sha256(sn_str.encode("utf-8")).hexdigest()[:8]
 
 
+def mask_url(url: str | None) -> str:
+    """Mask a URL host and webhook ID to prevent leaks in logs."""
+    if not url:
+        return ""
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(str(url))
+        # Mask netloc
+        # For path, mask the final part which is the webhook ID (e.g. /api/webhook/hyxi_cloud_abc123)
+        path_parts = parsed.path.strip("/").split("/")
+        if path_parts:
+            # Check if it looks like a webhook ID
+            if path_parts[-1].startswith("hyxi_cloud_"):
+                path_parts[-1] = "hyxi_cloud_***"
+            elif len(path_parts[-1]) > 10:  # arbitrary long ID
+                path_parts[-1] = "***"
+        masked_path = "/" + "/".join(path_parts)
+        return f"{parsed.scheme}://[MASKED_DOMAIN]{masked_path}"
+    except Exception:  # pylint: disable=broad-except
+        return "https://[MASKED_DOMAIN]/api/webhook/hyxi_cloud_***"
+
+
 def mask_sensitive_key_value(key: str, value: Any) -> Any:
     """Check if key contains sensitive info (SN, plant ID, IMEI, alias, address, etc.) and mask it."""
     if value is None:

--- a/tests/test_alarm_push.py
+++ b/tests/test_alarm_push.py
@@ -303,5 +303,5 @@ async def test_handle_alarm_webhook_logging_details(
         log_msg = debug_log[0]
 
         # Verify webhook ID and active subscribe code are logged correctly
-        assert "Webhook ID: hyxi_cloud_entry_test_alarm" in log_msg
+        assert "Webhook ID: hyxi_cloud_***" in log_msg
         assert "Active Subscribe Code: coord-alarm-sub-code" in log_msg

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -6,6 +6,7 @@ from custom_components.hyxi_cloud.const import (
     get_software_version,
     is_null_value,
     mask_sn,
+    mask_url,
     normalize_device_type,
 )
 
@@ -243,3 +244,22 @@ def test_detect_phase_type_unknown():
     assert detect_phase_type({"model": ""}) == "unknown"
     assert detect_phase_type({"model": "SomeRandomModel"}) == "unknown"
     assert detect_phase_type({"model": None, "metrics": {}}) == "unknown"
+
+
+def test_mask_url():
+    """Verify mask_url correctly obscures URLs."""
+    # 1. Custom URL webhook
+    assert (
+        mask_url("https://example.com/api/webhook/hyxi_cloud_entry_123")
+        == "https://[MASKED_DOMAIN]/api/webhook/hyxi_cloud_***"
+    )
+
+    # 2. Nabu Casa webhook
+    assert (
+        mask_url("https://hooks.nabucasa.com/v1/abc123xyz789")
+        == "https://[MASKED_DOMAIN]/v1/***"
+    )
+
+    # 3. None or empty
+    assert mask_url("") == ""
+    assert mask_url(None) == ""

--- a/tests/test_push_integration.py
+++ b/tests/test_push_integration.py
@@ -377,7 +377,7 @@ async def test_webhook_handler_logging_details(mock_coordinator, caplog):
         log_msg = debug_log[0]
 
         # Verify webhook ID and active subscribe code are logged correctly
-        assert "Webhook ID: webhook_123" in log_msg
+        assert "Webhook ID: ***" in log_msg
         assert "Active Subscribe Code: coord-sub-code" in log_msg
 
 


### PR DESCRIPTION
## Summary
This PR resolves a data leakage issue in the debug and info logs of the `ha-hyxi-cloud` Home Assistant integration, where webhook URLs, webhook IDs, and device serial numbers were being written raw.

Fixes Veldkornet/ha-hyxi-cloud#496

## Key Changes
* Added a `mask_url` helper in `custom_components/hyxi_cloud/const.py` to securely redact the external domain/IP address (`[MASKED_DOMAIN]`) and the unique webhook ID suffix (`***`) from callback URLs.
* Masked all webhook URL logging in `custom_components/hyxi_cloud/__init__.py`.
* Masked device serial numbers in webhook subscription logs using `mask_sn()`.
* Redacted the webhook ID suffix in webhook callback logs to ensure path identifiers are not leaked.
* Added `test_mask_url` unit tests in `tests/test_const.py` and updated assertions in `tests/test_alarm_push.py` and `tests/test_push_integration.py`.

## Why this is needed
Logging raw external domain names, webhook IDs, and device serial numbers poses a privacy risk when users paste logs for troubleshooting or sharing in GitHub issues. Masking these values ensures customer network and device identifiers remain confidential.
