### PR TITLE
fix: cancel and unregister subscription codes on push deactivation

### DIFF
--- a/custom_components/hyxi_cloud/__init__.py
+++ b/custom_components/hyxi_cloud/__init__.py
@@ -90,11 +90,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
-    # Set up real-time push subscription if enabled (graceful fallback to polling if it fails)
+    # Set up real-time push subscription (handles enablement checks and cleanup of orphaned codes)
     await _async_setup_push_subscription(hass, entry, coordinator)
-    # Set up alarm push subscription (runs alongside data push, same webhook base URL)
-    if entry.options.get(CONF_ENABLE_PUSH, False):
-        await _async_setup_alarm_subscription(hass, entry, coordinator)
+    # Set up alarm push subscription (handles enablement checks and cleanup of orphaned codes)
+    await _async_setup_alarm_subscription(hass, entry, coordinator)
 
     device_registry = dr.async_get(hass)
 
@@ -385,6 +384,23 @@ async def _async_setup_push_subscription(  # pylint: disable=too-many-statements
     enable_push = entry.options.get(CONF_ENABLE_PUSH, False)
     if enable_push is not True:
         coordinator.push_status = "inactive"
+        prior_code = entry.data.get("push_subscribe_code")
+        if prior_code:
+            _LOGGER.debug(
+                "HYXI Push: Cancelling prior subscription on push disable (code: %s)",
+                prior_code,
+            )
+            try:
+                await async_cancel_and_unregister_subscription(
+                    hass, coordinator.client, prior_code
+                )
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug(
+                    "HYXI Push: Could not cancel subscription on push disable: %s", err
+                )
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, "push_subscribe_code": None}
+            )
         return
 
     # Cancel any previously-active subscription that wasn't cleanly torn down
@@ -394,7 +410,9 @@ async def _async_setup_push_subscription(  # pylint: disable=too-many-statements
             "HYXI Push: Cancelling prior orphaned subscription (code: %s)", prior_code
         )
         try:
-            await coordinator.client.cancel_subscription(prior_code)
+            await async_cancel_and_unregister_subscription(
+                hass, coordinator.client, prior_code
+            )
         except Exception as err:  # pylint: disable=broad-exception-caught
             _LOGGER.debug("HYXI Push: Could not cancel prior subscription: %s", err)
         hass.config_entries.async_update_entry(
@@ -641,6 +659,29 @@ async def _async_setup_alarm_subscription(
     The alarm subscribe_code is persisted to entry.data under
     "alarm_subscribe_code" for crash-safe teardown on next startup.
     """
+    enable_push = entry.options.get(CONF_ENABLE_PUSH, False)
+    if enable_push is not True:
+        coordinator.alarm_push_status = "inactive"
+        prior_code = entry.data.get("alarm_subscribe_code")
+        if prior_code:
+            _LOGGER.debug(
+                "HYXI Alarm Push: Cancelling prior subscription on push disable (code: %s)",
+                prior_code,
+            )
+            try:
+                await async_cancel_and_unregister_subscription(
+                    hass, coordinator.client, prior_code
+                )
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                _LOGGER.debug(
+                    "HYXI Alarm Push: Could not cancel subscription on push disable: %s",
+                    err,
+                )
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, "alarm_subscribe_code": None}
+            )
+        return
+
     push_rate_s = int(entry.options.get(CONF_PUSH_RATE, DEFAULT_PUSH_RATE))
     push_rate_ms = push_rate_s * 1000
     custom_url = entry.options.get(CONF_PUSH_URL)
@@ -656,7 +697,9 @@ async def _async_setup_alarm_subscription(
             prior_code,
         )
         try:
-            await coordinator.client.cancel_subscription(prior_code)
+            await async_cancel_and_unregister_subscription(
+                hass, coordinator.client, prior_code
+            )
         except Exception as err:  # pylint: disable=broad-exception-caught
             _LOGGER.debug(
                 "HYXI Alarm Push: Could not cancel prior subscription: %s", err

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1187,3 +1187,39 @@ async def test_additional_init_coverage(mock_hass, mock_entry):
                                     assert res_unload is True
                                     mock_engine.async_stop.assert_called_once()
                                     mock_controller.async_stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_push_deactivation_cleanup(mock_hass, mock_entry):
+    """Verify push deactivation cleans up active/stored subscription codes."""
+    from custom_components.hyxi_cloud.const import CONF_ENABLE_PUSH
+
+    mock_entry.options = {CONF_ENABLE_PUSH: False}
+    mock_entry.data = {
+        "push_subscribe_code": "sub_code_123",
+        "alarm_subscribe_code": "alarm_code_123",
+    }
+
+    coordinator = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client.cancel_subscription = AsyncMock(return_value={"success": True})
+
+    with patch(
+        "custom_components.hyxi_cloud.__init__.async_cancel_and_unregister_subscription",
+        new=AsyncMock(),
+    ) as mock_cancel:
+        await _async_setup_push_subscription(mock_hass, mock_entry, coordinator)
+        await _async_setup_alarm_subscription(mock_hass, mock_entry, coordinator)
+
+        # Verify cancel and unregister was called for both
+        assert mock_cancel.call_count == 2
+        mock_cancel.assert_any_call(mock_hass, coordinator.client, "sub_code_123")
+        mock_cancel.assert_any_call(mock_hass, coordinator.client, "alarm_code_123")
+
+        # Verify config entry data was updated to clear the codes
+        mock_hass.config_entries.async_update_entry.assert_any_call(
+            mock_entry, data={**mock_entry.data, "push_subscribe_code": None}
+        )
+        mock_hass.config_entries.async_update_entry.assert_any_call(
+            mock_entry, data={**mock_entry.data, "alarm_subscribe_code": None}
+        )


### PR DESCRIPTION
## Summary
This Pull Request addresses an issue where subscription codes persisted in the `known_subscription_codes` sensor attribute after a user deactivated the real-time push data configuration. Deactivating the push configuration now automatically cancels the subscriptions on the API side and unregisters them from Home Assistant's local persistent storage.

## Key Changes
- **Unconditional Setup Invocation**: Modified `async_setup_entry` to unconditionally invoke `_async_setup_push_subscription` and `_async_setup_alarm_subscription` so they can run deactivation cleanup if push is disabled.
- **Deactivation Cleanup Logic**: Added checks in both setup routines to detect when push is disabled (`enable_push` is `False`) while a prior `push_subscribe_code` or `alarm_subscribe_code` exists. They now invoke `async_cancel_and_unregister_subscription` and clear the codes from `entry.data`.
- **Direct API Call Replacement**: Replaced raw `client.cancel_subscription` calls with `async_cancel_and_unregister_subscription` during startup cleanup, ensuring the local storage stays in sync.
- **Unit Testing**: Added `test_async_setup_push_deactivation_cleanup` in `tests/test_init.py` to assert correct cleanup behavior.

## Why this is needed
Previously, disabling push configuration bypassed the alarm subscription logic and returned early in the push subscription setup without modifying the local persistent storage. This left stale subscription codes in Home Assistant's state attributes, causing a discrepancy between the local UI state and the actual API subscription status and requiring a manual purge.
