### PR TITLE
fix: scale anti-spike threshold by elapsed time to prevent lockout

### DIFF
--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -1073,6 +1073,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
         """Initialize the base sensor."""
         super().__init__(coordinator)
         self._last_valid_value = None
+        self._last_valid_time = None
         self._last_logged_glitch = None
 
     def _update_native_value(self):
@@ -1131,13 +1132,25 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
         """Check for and prevent impossible value jumps."""
         if self._last_valid_value is None:
             return None
-        if (num_value - self._last_valid_value) > 100.0:
+
+        # Allow threshold scaling based on time elapsed since the last update
+        time_elapsed_hours = 168.0  # Default to 1 week if last update time is unknown
+        if getattr(self, "_last_valid_time", None) is not None:
+            now = dt_util.utcnow()
+            time_elapsed_hours = max(
+                0.0, (now - self._last_valid_time).total_seconds() / 3600.0
+            )
+
+        max_allowed_jump = round(100.0 + (50.0 * time_elapsed_hours), 2)
+
+        if (num_value - self._last_valid_value) > max_allowed_jump:
             self._log_glitch_once(
                 num_value,
-                "HYXI High-Spike Filter: Ignoring impossible jump on %s from %s to %s",
+                "HYXI High-Spike Filter: Ignoring impossible jump on %s from %s to %s (max allowed: %s)",
                 self.entity_description.key,
                 self._last_valid_value,
                 num_value,
+                max_allowed_jump,
             )
             return self._last_valid_value
 
@@ -1167,6 +1180,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
                     if spike_result is not None:
                         return spike_result
             self._last_valid_value = num_value
+            self._last_valid_time = dt_util.utcnow()
             return num_value
         except ValueError, TypeError:
             return value

--- a/tests/test_sensor_logic.py
+++ b/tests/test_sensor_logic.py
@@ -827,10 +827,15 @@ async def test_base_sensor_added_to_hass_invalid_restoration():
 
 def test_anti_spike_direct_call(base_sensor):
     """Directly test _check_anti_spike logic and coverage."""
+    from datetime import timedelta
+
+    import homeassistant.util.dt as dt_util
+
     sensor, _ = base_sensor
 
-    # Initialize _last_valid_value
+    # Initialize _last_valid_value and time
     sensor._last_valid_value = 100.0
+    sensor._last_valid_time = dt_util.utcnow()
 
     # Valid jump <= 100.0 returns None (meaning let it through)
     assert sensor._check_anti_spike(200.0) is None
@@ -840,11 +845,19 @@ def test_anti_spike_direct_call(base_sensor):
         assert sensor._check_anti_spike(200.1) == 100.0
         mock_log.assert_called_once_with(
             200.1,
-            "HYXI High-Spike Filter: Ignoring impossible jump on %s from %s to %s",
+            "HYXI High-Spike Filter: Ignoring impossible jump on %s from %s to %s (max allowed: %s)",
             sensor.entity_description.key,
             100.0,
             200.1,
+            100.0,
         )
+
+    # If the last update was a long time ago (e.g. 3 hours), a larger jump is allowed
+    sensor._last_valid_time = dt_util.utcnow() - timedelta(hours=3)
+    # Allowed jump is 100.0 + 50.0 * 3 = 250.0. A jump of 249.0 should be allowed.
+    assert sensor._check_anti_spike(349.0) is None
+    # A jump of 251.0 should still be blocked
+    assert sensor._check_anti_spike(351.0) == 100.0
 
 
 def test_anti_dip_direct_call(base_sensor):
@@ -861,10 +874,13 @@ def test_anti_dip_direct_call(base_sensor):
 
 def test_process_numeric_value_anti_spike(base_sensor):
     """Test the return path for _check_anti_spike inside _process_numeric_value."""
+    import homeassistant.util.dt as dt_util
+
     sensor, _ = base_sensor
 
-    # Seed an existing valid value
+    # Seed an existing valid value and time
     sensor._last_valid_value = 100.0
+    sensor._last_valid_time = dt_util.utcnow()
 
     # Pass a value that creates a spike > 100.0
     # _process_numeric_value handles rounding internally, so 200.11 will trigger the spike block


### PR DESCRIPTION
## Summary
This Pull Request fixes a bug in the sensor's anti-spike filter (`_check_anti_spike`) where cumulative energy counters (total increasing state class, such as Total Battery Charge/Discharge) would stop updating permanently if the actual value jumped by more than 100.0 kWh during downtime, reload, or after a restart.

Fixes #509.

## Key Changes
- **Time-Scaled Threshold**: Introduced `self._last_valid_time` to track when the last valid value was accepted. The anti-spike jump threshold now scales dynamically with the hours elapsed since the last update (`max_allowed_jump = 100.0 + 50.0 * time_elapsed_hours`).
- **Flexible Startup catch-up**: When `self._last_valid_time` is `None` (after configuration entry restart or restore), the threshold defaults to a large time window (1 week / 168 hours) to allow the sensor to sync with the current value on the API.
- **Maintained Transient Glitch Protection**: On normal 5-minute update frequencies, the allowed jump threshold resolves back to the original `100.0` kWh limit, preserving the protection against cloud API "ghost spikes".
- **Enhanced Test Suite**: Updated and expanded `test_anti_spike_direct_call` and `test_process_numeric_value_anti_spike` in `tests/test_sensor_logic.py` to cover time-scaled anti-spike logic.

## Why this is needed
Previously, the jump threshold was hardcoded to a static `100.0` kWh. If the integration went offline, or if Home Assistant was stopped for a period where the user's actual cumulative charged/discharged energy increased by more than 100 kWh, the first update from the API was rejected as a spike. The sensor would revert to its restored value, causing all subsequent correct updates to be rejected indefinitely and permanently locking the sensor out.
