### PR TITLE
chore: bump hyxi-cloud-api to 1.3.7 to fix stuck cumulative battery sensors

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -15,7 +15,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.3.6"
+    "hyxi-cloud-api>=1.3.7"
   ],
   "version": "1.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.3.6"
+    "hyxi-cloud-api>=1.3.7"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.3.6
+hyxi-cloud-api>=1.3.7
 
 # Development/Linting tools
 ruff>=0.15.17

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.155.2
-hyxi-cloud-api>=1.3.6
+hyxi-cloud-api>=1.3.7
 pytest-homeassistant-custom-component>=0.13.339


### PR DESCRIPTION
## Summary

Bumps the `hyxi-cloud-api` dependency version requirement to `>=1.3.7` to import the unified cumulative battery energy key mapping and telemetry fixes.

## Key Changes

- **`custom_components/hyxi_cloud/manifest.json`**: Updated dependency to `hyxi-cloud-api>=1.3.7`.
- **`pyproject.toml`**: Updated dependency to `hyxi-cloud-api>=1.3.7`.
- **`requirements.txt`**: Updated integration dependency to `hyxi-cloud-api>=1.3.7`.
- **`requirements_test.txt`**: Updated test dependency to `hyxi-cloud-api>=1.3.7`.

## Why This Is Needed

Version `1.3.7` of the API client library contains critical updates that synchronize REST-polled telemetry keys (`totalEchg` / `totalEdchg`) and websocket push keys (`batCharge` / `batDisCharge`) into the single, unified `bat_charge_total` and `bat_discharge_total` metrics. Without this dependency bump, integration installations relying on REST polling will continue to have their cumulative charge/discharge battery sensors permanently stuck on their restored startup values.

Fixes: #509

## Verification

Run all local unit tests:
```bash
python3 -m pytest
```
Result: 312 passed, 1 skipped, 2 warnings in 0.77s.
