### PR TITLE
chore: add version check hook to verify integration and dependency versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,6 +26,7 @@ jobs:
             productionresultssa16.blob.core.windows.net:443
             productionresults*.blob.core.windows.net:443
             proxy.golang.org:443
+            storage.googleapis.com:443
             sum.golang.org:443
             dl.google.com:443
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,10 @@ jobs:
             pypi.org:443
             productionresultssa16.blob.core.windows.net:443
             productionresults*.blob.core.windows.net:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            dl.google.com:443
+
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4.2.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.3.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
             productionresultssa16.blob.core.windows.net:443
             productionresults*.blob.core.windows.net:443

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,8 @@ repos:
         entry: 'except\s*\([^)]+,\s*[^)]+\)\s*:'
         language: pygrep
         types: [python]
+      - id: check-versions
+        name: "Check version synchronization"
+        entry: python3 scripts/check_versions.py
+        language: system
+        pass_filenames: false

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -47,7 +47,7 @@ def main() -> None:
     )
 
     # Extract hyxi-cloud-api dependency
-    pyproject_api_match = re.search(r'"(hyxi-cloud-api[>=~<=]*.*?)"', pyproject_content)
+    pyproject_api_match = re.search(r'"(hyxi-cloud-api[>=~<]*.*?)"', pyproject_content)
     pyproject_api_version = (
         pyproject_api_match.group(1) if pyproject_api_match else None
     )

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -52,7 +52,22 @@ def main() -> None:
         pyproject_api_match.group(1) if pyproject_api_match else None
     )
 
-    # 3. Read requirements.txt
+    # 3. Read const.py
+    const_path = root / "custom_components" / "hyxi_cloud" / "const.py"
+    if not const_path.exists():
+        print(f"Error: const.py not found at {const_path}")
+        sys.exit(1)
+
+    with const_path.open("r", encoding="utf-8") as f:
+        const_content = f.read()
+
+    # Extract VERSION
+    const_version_match = re.search(
+        r'^VERSION\s*=\s*"(.*?)"', const_content, re.MULTILINE
+    )
+    const_version = const_version_match.group(1) if const_version_match else None
+
+    # 4. Read requirements.txt
     req_path = root / "requirements.txt"
     req_api_version = None
     if req_path.exists():
@@ -62,7 +77,7 @@ def main() -> None:
                     req_api_version = line.strip()
                     break
 
-    # 4. Read requirements_test.txt
+    # 5. Read requirements_test.txt
     req_test_path = root / "requirements_test.txt"
     req_test_api_version = None
     if req_test_path.exists():
@@ -75,12 +90,15 @@ def main() -> None:
     errors = []
 
     # Check integration versions
-    if manifest_version != pyproject_version:
-        errors.append(
-            f"Integration version mismatch:\n"
-            f"  manifest.json: {manifest_version}\n"
-            f"  pyproject.toml: {pyproject_version}"
-        )
+    integration_versions = {
+        "manifest.json": manifest_version,
+        "pyproject.toml": pyproject_version,
+        "const.py": const_version,
+    }
+
+    if len(set(integration_versions.values())) > 1:
+        details = "\n".join(f"  {k}: {v}" for k, v in integration_versions.items())
+        errors.append(f"Integration version mismatch:\n{details}")
 
     # Check hyxi-cloud-api dependency versions
     api_versions = {

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Check that all version strings and dependency version requirements are in sync."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Verify integration versions and dependency declarations are synchronized."""
+    root = Path(__file__).parent.parent
+
+    # 1. Read manifest.json
+    manifest_path = root / "custom_components" / "hyxi_cloud" / "manifest.json"
+    if not manifest_path.exists():
+        print(f"Error: manifest.json not found at {manifest_path}")
+        sys.exit(1)
+
+    with manifest_path.open("r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    manifest_version = manifest.get("version")
+
+    # Find hyxi-cloud-api version in manifest requirements
+    manifest_api_version = None
+    for req in manifest.get("requirements", []):
+        if "hyxi-cloud-api" in req:
+            manifest_api_version = req.strip()
+            break
+
+    # 2. Read pyproject.toml
+    pyproject_path = root / "pyproject.toml"
+    if not pyproject_path.exists():
+        print(f"Error: pyproject.toml not found at {pyproject_path}")
+        sys.exit(1)
+
+    with pyproject_path.open("r", encoding="utf-8") as f:
+        pyproject_content = f.read()
+
+    # Extract version
+    pyproject_version_match = re.search(
+        r'^version\s*=\s*"(.*?)"', pyproject_content, re.MULTILINE
+    )
+    pyproject_version = (
+        pyproject_version_match.group(1) if pyproject_version_match else None
+    )
+
+    # Extract hyxi-cloud-api dependency
+    pyproject_api_match = re.search(r'"(hyxi-cloud-api[>=~<=]*.*?)"', pyproject_content)
+    pyproject_api_version = (
+        pyproject_api_match.group(1) if pyproject_api_match else None
+    )
+
+    # 3. Read requirements.txt
+    req_path = root / "requirements.txt"
+    req_api_version = None
+    if req_path.exists():
+        with req_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip().startswith("hyxi-cloud-api"):
+                    req_api_version = line.strip()
+                    break
+
+    # 4. Read requirements_test.txt
+    req_test_path = root / "requirements_test.txt"
+    req_test_api_version = None
+    if req_test_path.exists():
+        with req_test_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip().startswith("hyxi-cloud-api"):
+                    req_test_api_version = line.strip()
+                    break
+
+    errors = []
+
+    # Check integration versions
+    if manifest_version != pyproject_version:
+        errors.append(
+            f"Integration version mismatch:\n"
+            f"  manifest.json: {manifest_version}\n"
+            f"  pyproject.toml: {pyproject_version}"
+        )
+
+    # Check hyxi-cloud-api dependency versions
+    api_versions = {
+        "manifest.json": manifest_api_version,
+        "pyproject.toml": pyproject_api_version,
+        "requirements.txt": req_api_version,
+        "requirements_test.txt": req_test_api_version,
+    }
+
+    # Clean version format comparison
+    non_null_versions = {k: v for k, v in api_versions.items() if v is not None}
+    if len(set(non_null_versions.values())) > 1:
+        details = "\n".join(f"  {k}: {v}" for k, v in non_null_versions.items())
+        errors.append(f"hyxi-cloud-api dependency version mismatch:\n{details}")
+
+    if errors:
+        for err in errors:
+            print(err)
+        sys.exit(1)
+
+    print("All integration and dependency versions are in sync!")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a pre-commit check hook and script to ensure that integration version declarations and dependency version requirements match across all project files.

## Key Changes

- **`scripts/check_versions.py`**: Script verifying:
  - Custom component version matches between `manifest.json` (`version`) and `pyproject.toml` (`version`).
  - `hyxi-cloud-api` dependency requirement is consistent across `manifest.json`, `pyproject.toml`, `requirements.txt`, and `requirements_test.txt`.
- **`.pre-commit-config.yaml`**: Registers the new script as a local pre-commit hook.

## Why This Is Needed

Prevents commits that introduce mismatched version declarations or conflicting dependency constraint requirements, ensuring a consistent setup.
