### PR TITLE
chore: bump hyxi-cloud-api to 1.3.8

### DIFF
--- a/custom_components/hyxi_cloud/manifest.json
+++ b/custom_components/hyxi_cloud/manifest.json
@@ -15,7 +15,7 @@
   ],
   "requirements": [
     "aiohttp>=3.13.4",
-    "hyxi-cloud-api>=1.3.7"
+    "hyxi-cloud-api>=1.3.8"
   ],
   "version": "1.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.13.5",
-    "hyxi-cloud-api>=1.3.7"
+    "hyxi-cloud-api>=1.3.8"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Integration Dependencies
 aiohttp>=3.13.4
 voluptuous>=0.16.0
-hyxi-cloud-api>=1.3.7
+hyxi-cloud-api>=1.3.8
 
 # Development/Linting tools
 ruff>=0.15.17

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@ pytest>=9.0.3
 pytest-asyncio>=1.3.0
 aiohttp>=3.13.4
 hypothesis>=6.155.2
-hyxi-cloud-api>=1.3.7
+hyxi-cloud-api>=1.3.8
 pytest-homeassistant-custom-component>=0.13.339


### PR DESCRIPTION
# Pull Request: Bump hyxi-cloud-api to 1.3.8

## Summary
Bumps the `hyxi-cloud-api` requirement to version `1.3.8` across the integration's manifest, pyproject configuration, and requirement definitions.

## Key Changes
- Bump `hyxi-cloud-api` constraint to `>=1.3.8` in `custom_components/hyxi_cloud/manifest.json`.
- Bump `hyxi-cloud-api` constraint to `>=1.3.8` in `pyproject.toml`.
- Bump `hyxi-cloud-api` constraint to `>=1.3.8` in `requirements.txt`.
- Bump `hyxi-cloud-api` constraint to `>=1.3.8` in `requirements_test.txt`.

## Why this is needed
This version bump is required to pull in the fixes from `hyxi-cloud-api` v1.3.8. In `v1.3.7`, a regression occurred where daily charging/discharging energy values (`batCharge`/`batDisCharge`) overwrote the lifetime cumulative values (`totalEchg`/`totalEdchg`) when both keys were present in the REST API payload (e.g. for the HYXi Halo). The daily values caused a drop in the Home Assistant sensors, triggering the anti-spike/anti-dip filters and preventing the sensors from recovering or updating. Version `1.3.8` corrects this mapping and priority logic to preserve both daily and cumulative metrics independently.
