### PR TITLE
fix: reset _last_valid_time on restore to unblock spike filter catchup on startup

### DIFF
--- a/custom_components/hyxi_cloud/sensor.py
+++ b/custom_components/hyxi_cloud/sensor.py
@@ -1089,6 +1089,7 @@ class HyxiBaseSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
             if (last_state := await self.async_get_last_state()) is not None:
                 try:
                     self._last_valid_value = float(last_state.state)
+                    self._last_valid_time = None
                     self._update_native_value()
                 except ValueError, TypeError:
                     _LOGGER.debug(

--- a/tests/test_sensor_logic.py
+++ b/tests/test_sensor_logic.py
@@ -553,6 +553,7 @@ async def test_sensor_added_to_hass_restoration():
     await sensor.async_added_to_hass()
 
     assert sensor._last_valid_value == 123.45
+    assert sensor._last_valid_time is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes a regression where cumulative battery energy sensors (e.g. `bat_charge_total`, `totalEchg`) that restore their state from the HA database on startup cannot recover to the correct live API value, because the spike filter blocks the jump as "impossible".

## Key Changes
- In `HyxiBaseSensor.async_added_to_hass`: explicitly reset `_last_valid_time = None` immediately after writing the restored `_last_valid_value` from the database.
- In `tests/test_sensor_logic.py`: added assertion that `_last_valid_time is None` after state restoration to lock in this behaviour.

## Why this is needed
When a `TOTAL_INCREASING` sensor is initialised, `_last_valid_time` is set to `utcnow()` during `__init__`. Milliseconds later, `async_added_to_hass` restores the old DB state (e.g. `3.3 kWh`) into `_last_valid_value` and calls `_update_native_value()` with the live API value (e.g. `467.7 kWh`). Because `_last_valid_time` was only milliseconds ago, `_check_anti_spike` computed an effective zero-hour elapsed window, capping the allowed jump at the `100.0 kWh` baseline. The delta of `464.4 kWh` exceeded this cap, permanently locking the sensor to its old restored value.

By resetting `_last_valid_time = None` after restoration, the spike filter defaults to the 1-week (`168`-hour) catch-up window, allowing a maximum jump of `8,500 kWh` on the first live update after startup — sufficient to recover any realistically stuck cumulative battery sensor without weakening glitch protection during normal steady-state operation.

Related: Issue #509
